### PR TITLE
Optimise build times from Jekyll --profile

### DIFF
--- a/_data/header.yaml
+++ b/_data/header.yaml
@@ -1,0 +1,18 @@
+# Specifies the top level links for the site header
+
+- section: Archives
+  href: /years/
+  slug: archives
+  icon: fa fa-ticket
+- section: People
+  href: /people/
+  slug: people
+  icon: fa fa-users
+- section: History
+  href: /history/
+  slug: history
+  icon: fa fa-book
+- section: About
+  href: /about/
+  slug: about
+  icon: octicon octicon-circuit-board

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,19 +9,12 @@
     </a>
 
     <nav class="site-nav">
-      {% assign top_pages = site.pages | where: "group", "top" | sort: "sort" %}
-      {% for node in top_pages %}
-        {% if node.title %}
-        <a class="page-link{% if node.current == page.current %} current{% endif %}" href="{{ node.url | prepend: site.baseurl }}">
+      {% for node in site.data.header %}
+        <a class="page-link{% if node.slug == page.current %} current{% endif %}" href="{{ node.href | prepend: site.baseurl }}">
           {% if node.icon %}<i class="{{ node.icon }}"></i> {% endif %}
-          <span class="page-link-text">{{ node.title }}</span>
+          <span class="page-link-text">{{ node.section }}</span>
         </a>
-        {% endif %}
       {% endfor %}
-      <a class="page-link{% if page.current == "about" %} current{% endif %}" href="/about/">
-        <i class="octicon octicon-circuit-board"></i>
-        <span class="page-link-text">About</span>
-      </a>
     </nav>
     <div class="site-search">
       {% if page.url != "/search/" %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,11 +12,6 @@
       {{site.time | date: "%Y-%m-%d %H:%M" }}, build {% include travis_build_number.txt %}, section {{ page.current }}
     </div>
 
-    <div class="debug-last-commit" data-debug-toggle>
-      <i class="octicon octicon-history"></i>
-      {% gitlastcommit %}
-    </div>
-
     <div class="debug-badges" data-debug-toggle>
       <a href="https://travis-ci.org/newtheatre/history-project">
         <img src="https://travis-ci.org/newtheatre/history-project.svg?branch=master" alt="Travis Build Badge" />

--- a/_sass/_debug.sass
+++ b/_sass/_debug.sass
@@ -27,16 +27,10 @@ $color-debug: #4FFF1F
   top: 2px
   left: 2px
 
-.debug-last-commit
-  @include debug-box
-  position: fixed
-  top: 2px + (14px + 2px + 2px) * 1
-  left: 2px
-
 .debug-badges
   @include debug-box
   position: fixed
-  top: 2px + (14px + 2px + 2px) * 2
+  top: 2px + (14px + 2px + 2px) * 1
   left: 2px
   padding: 3px 3px 1px 3px
 

--- a/about.md
+++ b/about.md
@@ -3,7 +3,6 @@ layout: about
 group: about
 current: about
 title: About This Site
-sort: 10
 published: true
 ---
 

--- a/history.md
+++ b/history.md
@@ -2,8 +2,6 @@
 layout: page
 title: History
 group: top
-sort: 30
-icon: fa fa-book
 current: history
 ---
 

--- a/people.md
+++ b/people.md
@@ -1,8 +1,6 @@
 ---
 layout: page
 title: Alumni
-sort: 20
-icon: "fa fa-users"
 group: top
 current: people
 published: true

--- a/recent_changes.md
+++ b/recent_changes.md
@@ -4,6 +4,7 @@ group: about
 current: about
 title: Recent Changes
 sort: 40
+regenerate: true
 ---
 
 # <i class="octicon octicon-history"></i> Recent Changes

--- a/years.html
+++ b/years.html
@@ -2,8 +2,6 @@
 layout: default
 title: Archives
 group: top
-sort: 10
-icon: fa fa-ticket
 editable: false
 search_exclude: true
 body_class: header-nobr


### PR DESCRIPTION
Couple of things to speed up build, found issues via Jekyll `--profile` tool.

- [x] Header links now come from a data file rather than pages having `group: top`, less magic and more config but ~80 secs saved
- [x] Remove the last commit sha and message from each pages debug view. Removes a feature but saves ~60 secs, is worth it I think. Pages still have the datetime they were generated at.
- [ ] #328 Optimise year graph