### PR TITLE
Year graph optimise

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,6 +26,6 @@
     </div>
   </div>
 
-{% include fancy/year_graph.html %}
+{{ site.data.year_graph }}
 
 </footer>

--- a/_plugins/log_adapter.rb
+++ b/_plugins/log_adapter.rb
@@ -1,0 +1,9 @@
+# Monkey patch the LogAdapter to change alignment of log messages
+
+module Jekyll
+  class LogAdapter
+    def formatted_topic(topic)
+      "#{topic} ".rjust(26)
+    end
+  end
+end

--- a/_plugins/year_graph.rb
+++ b/_plugins/year_graph.rb
@@ -1,0 +1,26 @@
+module Jekyll
+  class YearGraphGenerator < Generator
+    priority :lowest
+
+    def generate(site)
+      Jekyll.logger.info "Processing year graph..."
+
+      path = File.join(site.source, '_includes/fancy/year_graph.html')
+
+      content = ''
+      f = File.open(path, "r")
+      f.each_line do |line|
+        content += line
+      end
+
+      payload = site.site_payload
+
+      info = {
+        filters:   [Jekyll::Filters],
+        registers: { :site => site, :page => payload['page'] }
+      }
+
+      site.data['year_graph'] = site.liquid_renderer.file(path).parse(content).render!(payload, info)
+    end
+  end
+end


### PR DESCRIPTION
Will close #328, also should address #326 year graph bug as single render.

This takes 10 seconds off the build time. We render the year graph once rather than on every page. As 1 < 1800 this is good.