### PR TITLE
Migrate from Google Fonts to self-hosted

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% if page.title %}{{ page.title }} &middot; {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 156 }}{% else %}{{ site.description }}{% endif %}">
-  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,400,300,600|Montserrat" />
   <link rel="stylesheet" href="/lib/github-issues-widget/github-issues-widget-default.css">
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}?cachebust={{ site.time | date: "%Y%m%d%H%M"}}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" data-proofer-ignore>

--- a/_sass/_header.sass
+++ b/_sass/_header.sass
@@ -63,13 +63,18 @@ $title-text-baseline: 1.2
 
   .logo-line-tnnt
     font-weight: normal
-    padding-top: 12px
+    padding-top: 11px
     font-family: $header-font-stack
     font-size: $title-text-size / 2
     line-height: ($title-text-size * $title-text-baseline) / 2
+    letter-spacing: -0.3px
 
   .logo-line-hp
     font-family: $header-font-stack
+    letter-spacing: $montserrat-letter-spacing
+
+    @include respond-down(mob-land)
+
 
   @include respond-down(tab-port)
     $title-text-size-tab-port: $title-text-size * 0.7
@@ -83,12 +88,15 @@ $title-text-baseline: 1.2
     $title-text-size-mob-land: $title-text-size * 0.6
     font-size: $title-text-size-mob-land
 
+    padding-left: 42px
+
     .logo-line-tnnt
       font-size: $title-text-size-mob-land / 2
       padding-top: 0
 
-    padding-left: 42px
-
+    .logo-line-hp
+      // Adjust line size from h2
+      line-height: 1.4em
 
 .site-nav
   @include grid-x-col(8)

--- a/_sass/_type.sass
+++ b/_sass/_type.sass
@@ -27,6 +27,8 @@ h1, h2, h3, h4, h5, h6, p, li, th, td, ul
 
 h1, h2, h3, h4, h5, h6
   font-family: $header-font-stack
+  // HACK correction from moving from GF Montserrat to latest
+  letter-spacing: $montserrat-letter-spacing
   @include block
 
 .h1-baseline

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,9 @@
     "jquery": "~2.1.4",
     "octicons": "https://github.com/wjdp/octicons.git#91e1adcd80bbb314f899e65971b39fac94489b4f",
     "lunr.js": "~0.6.0",
-    "letteringjs": "~0.7.0"
+    "letteringjs": "~0.7.0",
+    "montserrat-webfont": "~1.0.3",
+    "open-sans-fontface": "~1.4.2"
   },
   "resolutions": {
     "bourbon": "~4.2.2"

--- a/css/main.sass
+++ b/css/main.sass
@@ -8,6 +8,7 @@ $site-url: "{{ site.url }}"
 // Our variables
 $body-font-stack: 'Open Sans', Helvetica, sans-serif
 $header-font-stack: 'Montserrat', sans-serif
+$montserrat-letter-spacing: -0.7px
 $base-font-size: 17px
 $base-font-size-compact:  $base-font-size * 0.875
 $baseline-multiplier: 1.6
@@ -54,7 +55,7 @@ $grid-row-padding: $baseline
 $grid-column-start: "tab-port"
 $grid-column-end: "mob-land"
 
-// Import partials from `sass_dir` (defaults to `_sass`)
+// Library imports
 
 @import "../lib/bourbon/app/assets/stylesheets/bourbon"
 @import "../lib/fgrid/fgrid"
@@ -68,7 +69,13 @@ $ionicons-font-path: "/lib/ionicons/fonts"
 $octicons-font-path: "/lib/octicons/octicons/"
 @import "../lib/octicons/octicons/sprockets-octicons.scss"
 
-// @import "pygments/monokai"
+$montserrat-font-path: "/lib/montserrat-webfont/fonts/"
+@import "../lib/montserrat-webfont/scss/montserrat-webfont"
+
+$OpenSansPath: "/lib/open-sans-fontface/fonts"
+@import "../lib/open-sans-fontface/sass/open-sans"
+
+// Import partials from `sass_dir` (defaults to `_sass`)
 
 @import "mixins"
 


### PR DESCRIPTION
**Will close #512** :capital_abcd: 

- Montserrat and Open Sans added to bower deps
- Both included in main.sass with font paths adjusted
- Style tweaks as GF Montserrat is not the same as everyone elses'