### PR TITLE
Rename smugmug attr in shows to prod_shots

### DIFF
--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -103,9 +103,9 @@ module Jekyll
     end
 
     def get_show_smugmug(show)
-      if show.data.key? "smugmug"
+      if show.data.key? "prod_shots"
         smug = Smug.new
-        return smug.get_show_photos(show.data["smugmug"], @site)
+        return smug.get_show_photos(show.data["prod_shots"], @site)
       else
         return nil
       end

--- a/_shows/05_06/blood_wedding.md
+++ b/_shows/05_06/blood_wedding.md
@@ -6,5 +6,5 @@ season: In House
 season_sort: 50
 venue: New Theatre
 
-smugmug: cWGWDN
+prod_shots: cWGWDN
 ---

--- a/_shows/05_06/cast_aside_edinburgh.md
+++ b/_shows/05_06/cast_aside_edinburgh.md
@@ -1,10 +1,10 @@
 ---
 title: Cast Aside
-playwright: 
+playwright:
 period: Edinburgh
 season: Edinburgh
 season_sort: 520
 venue: The Zoo
 
-smugmug: 7FLqSZ
+prod_shots: 7FLqSZ
 ---

--- a/_shows/05_06/oedipus_rex.md
+++ b/_shows/05_06/oedipus_rex.md
@@ -6,5 +6,5 @@ season: In House
 season_sort: 70
 venue: New Theatre
 
-smugmug: sqT2gq
+prod_shots: sqT2gq
 ---

--- a/_shows/05_06/persae.md
+++ b/_shows/05_06/persae.md
@@ -6,5 +6,5 @@ season: Edinburgh
 season_sort: 500
 venue: Underbelly
 
-smugmug: TwwS6j
+prod_shots: TwwS6j
 ---

--- a/_shows/05_06/popcorn.md
+++ b/_shows/05_06/popcorn.md
@@ -21,6 +21,6 @@ cast:
 assets:
   - type: poster
     image: popcorn.jpg
-  
-smugmug: c7H5NP
+
+prod_shots: c7H5NP
 ---

--- a/_shows/05_06/the_cradle.md
+++ b/_shows/05_06/the_cradle.md
@@ -6,5 +6,5 @@ season: In House
 season_sort: 90
 venue: New Theatre
 
-smugmug: nwRgGK
+prod_shots: nwRgGK
 ---

--- a/_shows/05_06/the_slippery_soapbox_edinburgh.md
+++ b/_shows/05_06/the_slippery_soapbox_edinburgh.md
@@ -1,6 +1,6 @@
 ---
 title: The Slippery Soapbox
-playwright: 
+playwright:
 period: Edinburgh
 season: Edinburgh
 season_sort: 510
@@ -12,6 +12,6 @@ assets:
   - type: poster
     image: slippery_soapbox_edinburgh.jpg
 
-smugmug: 7FLqSZ
+prod_shots: 7FLqSZ
 ---
 

--- a/_shows/06_07/4_48_psychosis.md
+++ b/_shows/06_07/4_48_psychosis.md
@@ -12,7 +12,7 @@ assets:
   - type: poster
     image: 448_psychosis.jpg
 
-smugmug: 6F3ctk
+prod_shots: 6F3ctk
 ---
 
 Sarah Kane is one of the most controversial and ground-breaking new playwrights of the late 20th Century. Inspired by Bond, Artaud, Beckett and Pinter, Sarah Kane represents athe new wave of British Contemporary playwrights. Her final play, 4.48 Psychosis was performed posthumously folowing her tragic suicide in 1999 and represents the culmination of her quest for new forms of theatre based on viceral personal expereince. A stark experience of the internal world of a clinical depressive on the verge of suicide, 4.48 Psychosis is viewed as aone of the most challenging works to have come out of Britain in the 1990s.

--- a/_shows/06_07/a_streetcar_named_desire.md
+++ b/_shows/06_07/a_streetcar_named_desire.md
@@ -14,7 +14,7 @@ assets:
   - type: poster
     image: streetcar_2.jpg
 
-smugmug: XT8Jwq
+prod_shots: XT8Jwq
 ---
 
 After falling on hard times, Blanche Dubois, an upper class teacher, decided to visit her sister, Stella. Upon arrival, Blanche is horrified to find Stella living in a New Orleans slum, and married to a working class brute. As a play progresses, Blanche's new surroundings creat intense drama and emotions, whilst bringing up painful revelations about her past life.

--- a/_shows/06_07/absurd_person_singular.md
+++ b/_shows/06_07/absurd_person_singular.md
@@ -12,7 +12,7 @@ assets:
   - type: poster
     image: absurd_person_singular.jpg
 
-smugmug: XKFt7R
+prod_shots: XKFt7R
 ---
 
 Three Christmases. Three kitchens. Three couples. A 'tragi-comedy' focusing on the importance of an outwardly appearing happy marriage in the 1970s, conveyed through behind-the-scenes disasters at Christmas parties. A charcter based cast including a multitude of emotions but if nothing else, laughter.

--- a/_shows/06_07/colder_than_here.md
+++ b/_shows/06_07/colder_than_here.md
@@ -8,7 +8,7 @@ venue: New Theatre
 date_start: 2007-05-02
 date_end: 2007-05-05
 
-smugmug: Dk5WqL
+prod_shots: Dk5WqL
 ---
 
 Nobody can ignore the fact that Myra is dying, but in the meantime life goes on. As a mother researches burial spots and biodegradable coffins, her family is finally forced to communicate with her, and each other, in this character driven play about life, death and everything in between.

--- a/_shows/06_07/fear_and_misery_of_the_3rd_reich.md
+++ b/_shows/06_07/fear_and_misery_of_the_3rd_reich.md
@@ -8,7 +8,7 @@ venue: New Theatre
 date_start: 2007-04-23
 date_end: 2007-04-28
 
-smugmug: MZQML6
+prod_shots: MZQML6
 ---
 
 From Brecht's series of twenty-four interconnected playlets, describing events which took place in ordinary German households in the 1930s. They dramatise with clinical precision the suspicion and anxiety experienced by ordinary people, particular Jewish citizens, as athe power of Hitler grew.

--- a/_shows/06_07/fish,_chips_and_mushy_peas.md
+++ b/_shows/06_07/fish,_chips_and_mushy_peas.md
@@ -12,7 +12,7 @@ assets:
   - type: poster
     image: fish_chips.jpg
 
-smugmug: zWxrtK
+prod_shots: zWxrtK
 ---
 
 Fish, Chips and Mushy Peas is essentailly a leap twenty years into the future, right here in the UK. A look at how far popular culture and politics could have moved; it examines the idea of reality TV in determining whether contestants may gain British citizenship. On a more personal note it explores the friendship of two people who have just entered a foreign environment together and their battle of morality against desire for the prize.

--- a/_shows/06_07/house_of_bernada_alba.md
+++ b/_shows/06_07/house_of_bernada_alba.md
@@ -11,7 +11,7 @@ date_end: 2007-03-13
 cast:
   - name: Emily Medhurst
 
-smugmug: PWJLr4
+prod_shots: PWJLr4
 ---
 
 Five sisters all live in the same house as their dominating mother. With strict rules and little freedom, the girls pine for love and excitement in their lives. Upon the discovery that one sistaer is to marry, a family rivalry develops causing adultery, betrayal and resentment.

--- a/_shows/06_07/humble_boy.md
+++ b/_shows/06_07/humble_boy.md
@@ -12,7 +12,7 @@ assets:
   - type: poster
     image: humble_boy.jpg
 
-smugmug: 9rBkt9
+prod_shots: 9rBkt9
 ---
 
 All is not well in the Humble hive. 35 year old Felix Humble is a Cambridge astrophysicist in search of a unified field theory. Following the of his father Felix, returns his middle England index and his difficult and demanding mother and soon realizes that his search for unity must include his own chaotic index life. Humble Boy us a 'tragi-comedy' about broken vows, failed hopes and the joys of bee-keeping!

--- a/_shows/06_07/jack_and_jill.md
+++ b/_shows/06_07/jack_and_jill.md
@@ -8,7 +8,7 @@ venue: New Theatre
 date_start: 2007-06-06
 date_end: 2007-06-09
 
-smugmug: JML6rm
+prod_shots: JML6rm
 ---
 
 When does love become obsession?

--- a/_shows/06_07/lysistrata.md
+++ b/_shows/06_07/lysistrata.md
@@ -8,7 +8,7 @@ venue: New Theatre
 date_start: 2007-06-12
 date_end: 2007-06-15
 
-smugmug: Wq6GPj
+prod_shots: Wq6GPj
 ---
 
 The scene is Athens at the height of the Peloponnesian war. A group of women, led by Lysistrata, have decided on an elaborate scheme to force me to make peace, by denying them sex. The result is a bawdy comedy with sexual politics at its heart.

--- a/_shows/06_07/rough_for_theatre_ii__ohio_impromptu.md
+++ b/_shows/06_07/rough_for_theatre_ii__ohio_impromptu.md
@@ -11,7 +11,7 @@ canonical:
   - title: Rough for Theatre II
   - title: Ohio Impromptu
 
-smugmug: dRQ4MN
+prod_shots: dRQ4MN
 ---
 
 Rough Theatre II and Ohio Impromptu represent Beckett's early and late career respectively. The plays vary in their style enormously, however what ties them together is the way Beckett manages to present the predicament of humanity itself with humour and indescribable beauty.

--- a/_shows/06_07/stars_in_their_eyes_fundraiser_.md
+++ b/_shows/06_07/stars_in_their_eyes_fundraiser_.md
@@ -10,5 +10,5 @@ assets:
   - type: poster
     image: stars_2007.jpg
 
-smugmug: Wrw4Jg
+prod_shots: Wrw4Jg
 ---

--- a/_shows/06_07/talking_to_terrorists.md
+++ b/_shows/06_07/talking_to_terrorists.md
@@ -10,7 +10,7 @@ date_end: 2007-02-24
 
 published: true
 
-smugmug: 5mqdTt
+prod_shots: 5mqdTt
 
 assets:
   - type: poster

--- a/_shows/06_07/the_flu_season.md
+++ b/_shows/06_07/the_flu_season.md
@@ -12,7 +12,7 @@ assets:
   - type: poster
     image: flu_season.jpg
 
-smugmug: MMRbHW
+prod_shots: MMRbHW
 ---
 
 Set in a hospital and in a theatre, a love story turns sour, a play is written in painful fits and starts, snow falls and turns to slush.

--- a/_shows/06_07/the_seagull.md
+++ b/_shows/06_07/the_seagull.md
@@ -14,7 +14,7 @@ assets:
   - type: poster
     image: the_seagull_2.jpg
 
-smugmug: BXFNXd
+prod_shots: BXFNXd
 ---
 
 The Seagull centers on the romantic and artistic conflicts of an ensemble cast of diverse and fully developed characters. Most centrally the aspiring actress Nina, the fading leading lady Irina Arkadina, her son the experimental playwright Konstantin Treplyov, and the famous middlebrow story writer Trigorin. This is a play about the pain of unrequited love and the power and problems of art.

--- a/_shows/06_07/through_the_looking_glass.md
+++ b/_shows/06_07/through_the_looking_glass.md
@@ -10,7 +10,7 @@ date_start: 2007-08-02
 date_end: 2007-08-27
 
 
-smugmug: vgSZgm
+prod_shots: vgSZgm
 ---
 
 Alice is in trouble! Can she survive the dangers of Looking Glass World and become Queen? Ingenious new musical production featuring an unforgettable fairground of characters including the Jabberwocky, the Red Queen and Humpty Dumpty.

--- a/_shows/06_07/vagina_monologues.md
+++ b/_shows/06_07/vagina_monologues.md
@@ -9,5 +9,5 @@ venue: New Theatre
 cast:
   - name: Emily Medhurst
 
-smugmug: RBNL4h
+prod_shots: RBNL4h
 ---

--- a/_shows/06_07/zoo_story.md
+++ b/_shows/06_07/zoo_story.md
@@ -12,7 +12,7 @@ assets:
   - type: poster
     image: zoostoryposter.jpg
 
-smugmug: Wh4bZc
+prod_shots: Wh4bZc
 ---
 
 Edward Albee's ground-breaking one-act play - lyrical, abrasive, daring and witty in theme and form. Two strangers meet in Central Park, and the ensuing dialogue, with a shocking ending, brings into question many of the values - family, friendship, security, ownership - that shapes our live.

--- a/_shows/07_08/bouncers_shakers.md
+++ b/_shows/07_08/bouncers_shakers.md
@@ -10,7 +10,7 @@ date_end: 2007-10-27
 canonical:
   - title: Bouncers
     playwright: John Godber
-  - title: Shakers 
+  - title: Shakers
     name: Jane Thornton
 
 crew:
@@ -19,7 +19,7 @@ crew:
   - role: Director
     name: Adam Paulden
 
-smugmug: pNfn7g
+prod_shots: pNfn7g
 
 assets:
   - type: poster

--- a/_shows/07_08/cant_stand_up_for_falling_down.md
+++ b/_shows/07_08/cant_stand_up_for_falling_down.md
@@ -15,7 +15,7 @@ crew:
   - role: Director
     name: Briony Gittins
 
-smugmug: CxTnwf
+prod_shots: CxTnwf
 ---
 
 A series of intertwining monologues exploring the past and present of three women who have never met yet are all deeply connected through the suffering that they have endured at the hand of one man. These poignant, partial perspectives reveal hidden strength despite the oppressive force of abuse, cruelty and loss.

--- a/_shows/07_08/crave.md
+++ b/_shows/07_08/crave.md
@@ -16,7 +16,7 @@ crew:
     - role: Director
       name: Fu Baxter
 
-smugmug: 39SzSb
+prod_shots: 39SzSb
 ---
 
 Set in an unnamed city from which voices and images spring, Crave charts the disintegration of a human mind under the pressures of love, loss and desire. Four nameless characters tell their tales, with poetic dialogues that meet, converge and move apart with balletic grace.

--- a/_shows/07_08/death_of_a_salesman.md
+++ b/_shows/07_08/death_of_a_salesman.md
@@ -12,7 +12,7 @@ crew:
   - role: Director
     name: Cal Lewis
 
-smugmug: 224bCp
+prod_shots: 224bCp
 ---
 
 Salesman Willy Loman is in a crisis. A slave to the capitalist system for so many years in continuous search of achieving the American dream, he is about to lose his job. He can't pay his bills, his sons don't respect him, and he never realised his potential. He wonders what went wrong and how he can make things up to his family.

--- a/_shows/07_08/good_morning_and_goodbye.md
+++ b/_shows/07_08/good_morning_and_goodbye.md
@@ -13,7 +13,7 @@ crew:
     - role: Director
       name: Nick Moran
 
-smugmug: CMNPKh
+prod_shots: CMNPKh
 ---
 
 Breakfast television talk shows are dull, lifeless and insipid, that is one thing that is beyond certain. And even the long suffering cast of 'Good morning and Goodbye' - Britain's 'most cheery way to start the day' - forced to live in a never-ending Prozac-laced world of pseudo-happiness, would not disagree with any accusation of blandness. However, today is a day unlike any other. A tremendous romp featuring religious cultists, celebrity chefs finally getting their due, and the truth about cold freezing, 'Good Morning and Goodbye' promises to deliver a slew of laughs and maybe even more...

--- a/_shows/07_08/macbeth.md
+++ b/_shows/07_08/macbeth.md
@@ -35,7 +35,7 @@ crew:
   - role: Designer
     name: Daniel Xavier Vizer
 
-smugmug: Ppd7Sb
+prod_shots: Ppd7Sb
 ---
 
 A one hour powerhouse production of the classic take of ambition, power, murder and madness. From the only student-run theatre in England, The New Theatre. In association with Ankle Productions winners of the National Student Drama Festival and an Edinburgh Festival Sell-Out company.

--- a/_shows/07_08/mixed_doubles.md
+++ b/_shows/07_08/mixed_doubles.md
@@ -8,5 +8,5 @@ venue: New Theatre
 date_start: 2007-10-17
 date_end: 2007-10-18
 
-smugmug: 9gCW4G
+prod_shots: 9gCW4G
 ---

--- a/_shows/07_08/no_exit.md
+++ b/_shows/07_08/no_exit.md
@@ -12,7 +12,7 @@ crew:
   - role: Director
     name: Meir Adler
 
-smugmug: nqcnP6
+prod_shots: nqcnP6
 ---
 
 One of Jean-Paul Sartre's most ground-breaking works delving into ideas of self-deception and human responsibility. Three characters from socially disparate backgrounds find themselves in Sartre's unique perception of hell. What follows is a tense and dramatic depiction of possibly the cruellest form of torture - the human imagination. Each of the characters soon realise that they themselves are the instruments of hell, and it is each other who will force them to reveal their deepest and darkest secrets.

--- a/_shows/07_08/out_of_order.md
+++ b/_shows/07_08/out_of_order.md
@@ -16,7 +16,7 @@ assets:
   - type: poster
     image: out_of_order_2007-08.jpg
 
-smugmug: XdwpkT
+prod_shots: XdwpkT
 ---
 
 It's 1991. Richard Willey MP is a member of the Conservative Cabinet. He is at the Westminster Hotel seducing Jane Worthington, one of the Leader of the Opposition's secretaries. Her suspicious husband, Ronnie, has been having her followed by a private detective, and is out to catch the man she's playing away with. Richard's secretary, George Pigden, comes to save the day, but accidentally gets married. On top of all this, Richard's wife turns up and ends up having a fling with George by mistake, but not before Ronnie has a break-down and admits his inadequacies...

--- a/_shows/07_08/proof.md
+++ b/_shows/07_08/proof.md
@@ -12,7 +12,7 @@ crew:
   - role: Director
     name: Guy Unsworth
 
-smugmug: Stmczp
+prod_shots: Stmczp
 
 assets:
   - type: poster

--- a/_shows/07_08/the_cranberry_chamber.md
+++ b/_shows/07_08/the_cranberry_chamber.md
@@ -9,7 +9,7 @@ venue: New Theatre
 date_start: 2008-02-13
 date_end: 2008-02-16
 
-smugmug: phxdJC
+prod_shots: phxdJC
 ---
 
 Do you like murder, intrigue and suspense? Do you like to control events and imagine yourself as some sort of all-powerful demi-God? If so then we think you might enjoy this...

--- a/_shows/07_08/the_crucible.md
+++ b/_shows/07_08/the_crucible.md
@@ -12,7 +12,7 @@ crew:
   - role: Director
     name: Cal Lewis
 
-smugmug: ssQzpS
+prod_shots: ssQzpS
 ---
 
 Whats some hearts desire, they must posess.

--- a/_shows/07_08/the_lonesome_west.md
+++ b/_shows/07_08/the_lonesome_west.md
@@ -13,7 +13,7 @@ crew:
   - role: Director
     name: Maia Gibbs
 
-smugmug: 5mN9pN
+prod_shots: 5mN9pN
 ---
 
 The play combines manic energy and physical violence in a way that is both hilarious and viscerally exciting" - "Daily Telegraph". Valene and Coleman, two brothers living alone in their father's house after his recent death, find it impossible to exist without the most massive and violent disputes over the most mundane and innocent of topics. Only father Welsh, the local young priest, is prepared to try to reconcile the two before their petty squabblings spiral into vicious and bloody carnage.

--- a/_shows/07_08/twinss.md
+++ b/_shows/07_08/twinss.md
@@ -9,7 +9,7 @@ venue: New Theatre
 date_start: 2008-02-06
 date_end: 2008-02-09
 
-smugmug: JRm8Gg
+prod_shots: JRm8Gg
 ---
 
 Theatrical Theatrics Productions proudly presents TwinSS, an almost-modern day Comedy of Errors by third year undergraduate Ali Blackwell.

--- a/_shows/07_08/under_the_blacklight.md
+++ b/_shows/07_08/under_the_blacklight.md
@@ -13,7 +13,7 @@ crew:
   - role: Director
     name: Nick Moran
 
-smugmug: bd5QFB
+prod_shots: bd5QFB
 
 assets:
   - type: poster

--- a/_shows/07_08/under_the_impression.md
+++ b/_shows/07_08/under_the_impression.md
@@ -13,7 +13,7 @@ crew:
   - role: Director
     name: Tom Warren
 
-smugmug: DtC6mw
+prod_shots: DtC6mw
 ---
 
 Jacob has hit a wall in his work. Frustratingly unable to complete a short story, he embarks on a desperate search for inspiration. However, as his personal pursuit for insight gains ground, Jacob finds himself increasingly alienated from the people around him. Despite this, he sees a conclusion in sight, although it's not quite what he had imagined...

--- a/_shows/08_09/a_bunch_of_talentless_wannabes.md
+++ b/_shows/08_09/a_bunch_of_talentless_wannabes.md
@@ -12,5 +12,5 @@ assets:
   - type: poster
     image: a_bunch_of_talentless_wannabees_2008-09.jpg
 
-smugmug: DVdGzx
+prod_shots: DVdGzx
 ---

--- a/_shows/08_09/look_back_in_anger.md
+++ b/_shows/08_09/look_back_in_anger.md
@@ -23,5 +23,5 @@ assets:
   - type: poster
     image: look_back_in_anger_2008-09.jpg
 
-smugmug: zrmf9s
+prod_shots: zrmf9s
 ---

--- a/_shows/08_09/nowhere_warm.md
+++ b/_shows/08_09/nowhere_warm.md
@@ -45,5 +45,5 @@ assets:
   - type: poster
     image: nowhere_warm_2008-09.jpg
 
-smugmug: zjH2L9
+prod_shots: zjH2L9
 ---

--- a/_shows/08_09/romeo_and_juliet.md
+++ b/_shows/08_09/romeo_and_juliet.md
@@ -20,7 +20,7 @@ crew:
     - role: Director
       name: Lizzie Bourne
 
-smugmug: zHWssh
+prod_shots: zHWssh
 
 assets:
   - type: poster

--- a/_shows/08_09/someone_wholl_watch_over_me.md
+++ b/_shows/08_09/someone_wholl_watch_over_me.md
@@ -29,5 +29,5 @@ assets:
   - type: poster
     image: someone_who_ll_watch_over_me_2008-09.jpg
 
-smugmug: f54j2s
+prod_shots: f54j2s
 ---

--- a/_shows/08_09/the_dumb_waiter.md
+++ b/_shows/08_09/the_dumb_waiter.md
@@ -11,5 +11,5 @@ assets:
   - type: poster
     image: the_dumb_waiter_2008-09.jpg
 
-smugmug: zfpsTT
+prod_shots: zfpsTT
 ---

--- a/_shows/08_09/the_pillowman.md
+++ b/_shows/08_09/the_pillowman.md
@@ -54,5 +54,5 @@ assets:
   - type: poster
     image: the_pillowman_2008-09.jpg
 
-smugmug: SRSrxr
+prod_shots: SRSrxr
 ---

--- a/_shows/08_09/warehouse_364.md
+++ b/_shows/08_09/warehouse_364.md
@@ -24,7 +24,7 @@ assets:
   - type: poster
     image: warehouse_364_poster.jpg
 
-smugmug: tVMbqg
+prod_shots: tVMbqg
 
 published: true
 ---

--- a/_shows/09_10/boys_life.md
+++ b/_shows/09_10/boys_life.md
@@ -50,7 +50,7 @@ assets:
 
 published: true
 
-smugmug: nGMwFs
+prod_shots: nGMwFs
 ---
 
 Set in the late 80's, Boys' Life tracks the misadventures of three former college mates as they simultaneously pursue and refuse adulthood; and the women who are both attracted to and repelled by them along the way. Told in a series of fast-paced and bitingly funny scenes, Boys' Life digs up some uncomfortable truths as the friends 'crawl through the gutter for regular sex.'

--- a/_shows/09_10/excess.md
+++ b/_shows/09_10/excess.md
@@ -33,7 +33,7 @@ assets:
 
 published: true
 
-smugmug: xGQFtD
+prod_shots: xGQFtD
 ---
 
 A tango bar. A bedroom.

--- a/_shows/09_10/freshers_fringe.md
+++ b/_shows/09_10/freshers_fringe.md
@@ -12,5 +12,5 @@ assets:
   - type: poster
     image: freshers_fringe_2009-10.jpg
 
-smugmug: vv4w85
+prod_shots: vv4w85
 ---

--- a/_shows/09_10/our_town.md
+++ b/_shows/09_10/our_town.md
@@ -30,7 +30,7 @@ assets:
 
 published: true
 
-smugmug: bNHmqg
+prod_shots: bNHmqg
 ---
 
 Our Town is Thornton Wilder's Pulitzer-prizewinning classic. The story follows George Gibbs and Emlly Webb from their first romance, to marriage and ultimately to Emily's death in childbirth.

--- a/_shows/09_10/the_country.md
+++ b/_shows/09_10/the_country.md
@@ -31,7 +31,7 @@ assets:
   - type: poster
     image: the_county_2009-10.jpg
 
-smugmug: jW4sSZ
+prod_shots: jW4sSZ
 
 published: true
 ---

--- a/_shows/09_10/the_importance_of_being_earnest.md
+++ b/_shows/09_10/the_importance_of_being_earnest.md
@@ -48,7 +48,7 @@ crew:
 
 published: true
 
-smugmug: sPzn5L
+prod_shots: sPzn5L
 ---
 
 The importance of being Earnest - To avoid family duties, Algernon Moncrieff, a bachelor-about-town, has invented Bunbury, a sick relative who frequently calls him away. His friend, Jack Worthing, has invented a wicked brother called Ernest to disguise his own misdemeanors. When Algernon poses as Ernest in order to meet the excessively pretty Cecily, confusion takes hold. And it's not until the full significance of an ordinary black handbag is discovered that Jack is allowed to marry his beloved Gwendolen.

--- a/_shows/09_10/the_shape_of_things.md
+++ b/_shows/09_10/the_shape_of_things.md
@@ -34,7 +34,7 @@ assets:
 
 published: true
 
-smugmug: mrtKV4
+prod_shots: mrtKV4
 ---
 
 An unconfident, unattractive English student in a Midwestern college enters, by means he cannot comprehend, into a relationship with a beautiful, enigmatic art student. Under her guidance he undergoes a huge physical transformation. But what is the price of beauty?

--- a/_shows/10_11/a_view_from_the_bridge.md
+++ b/_shows/10_11/a_view_from_the_bridge.md
@@ -53,7 +53,7 @@ assets:
 
 published: true
 
-smugmug: 7dbktp
+prod_shots: 7dbktp
 ---
 
 “I was just thinking before, comin’ home, suppose my father didn’t come to this country, and I was starving like them over there … and I had people in America could keep me for a couple of months? The man would be honoured to lend me a place to sleep.”

--- a/_shows/10_11/after_the_end.md
+++ b/_shows/10_11/after_the_end.md
@@ -37,7 +37,7 @@ crew:
 
 published: true
 
-smugmug: 4DbWrF
+prod_shots: 4DbWrF
 
 assets:
   - type: poster

--- a/_shows/10_11/arcadia.md
+++ b/_shows/10_11/arcadia.md
@@ -58,7 +58,7 @@ assets:
 
 published: true
 
-smugmug: 4d8T8x
+prod_shots: 4d8T8x
 ---
 
 "When we have found all the mysteries and lost all the meanings, we will be alone, on an empty shore"

--- a/_shows/10_11/bluebird.md
+++ b/_shows/10_11/bluebird.md
@@ -40,7 +40,7 @@ assets:
 
 published: true
 
-smugmug: hK3T2p
+prod_shots: hK3T2p
 ---
 
 “This is an extraordinary city. It's a city that you should see primarily at nighttime. It is becomes more concentrated at nighttime. We could take a look at it for a while...”

--- a/_shows/10_11/caucasian_chalk_circle.md
+++ b/_shows/10_11/caucasian_chalk_circle.md
@@ -31,7 +31,7 @@ assets:
 
 published: true
 
-smugmug: HqbXJm
+prod_shots: HqbXJm
 ---
 
 The city burns in the heat of civil war and a servant girl sacrifices everything to protect an abandoned child. But when peace is finally restored, the boy's mother comes to claim him. Calling upon the ancient tradition of the chalk circle, a comical judge sets about resolving the dispute. But in a culture of corruption and deception, who wins?

--- a/_shows/10_11/deus_vult.md
+++ b/_shows/10_11/deus_vult.md
@@ -35,7 +35,7 @@ assets:
 
 published: true
 
-smugmug: 2PCKHm
+prod_shots: 2PCKHm
 ---
 
 In 1127 a young landlady's thoughts of turning to prostitution for financial salvation are interrupted by the arrival of an old man who can only pay for his drink with a story. His tale takes them to the Holy Land 30 years previously, amidst the horror of the First Crusade, where the man and his friend were spared a hanging upon agreeing to cross into enemy territory and retrieve an artefact behind which an army could take Jerusalem. As the story unfolds the landlady is forced to examine her life and reflect upon her inadequacies as well as the need for redemption that she has only a swearing, thieving, whoring, boozing old outlaw to help her find. Deus Vult is not a historical play; it is a modern play about relatable people struggling with the timeless issues of fear, loyalty and morality. Above all it is about humanity's never-ending struggle to seek a glimmer of light in a world of filth and emptiness.

--- a/_shows/10_11/flare_path.md
+++ b/_shows/10_11/flare_path.md
@@ -9,8 +9,6 @@ date_start: 2010-12-07
 date_end: 2010-12-10
 
 cast:
-- role: Peter Kyle
-  name: Izzy Scrimshire
 - role: Countess Dorris Skriczevinsky
   name: Laura Kaye Thomson
 - role: Mrs Oakes
@@ -59,7 +57,7 @@ assets:
 
 published: true
 
-smugmug: HXQWpd
+prod_shots: HXQWpd
 ---
 
 1941, and the Falcon hotel in Milchester plays host to the brave young men of the RAF and their loved ones. Patricia, wife of the charming and heroic Flight-Lieutenant Teddy Graham arrives to tell him that she is leaving him for her old flame, Hollywood heartthrob Peter Kyle. However, when Teddy and the others are called off on a dangerous night bombing mission and things start to go awry, Patricia struggles to find the right moment to break her news.

--- a/_shows/10_11/hedda_gabler.md
+++ b/_shows/10_11/hedda_gabler.md
@@ -36,7 +36,7 @@ assets:
 
 published: true
 
-smugmug: BF99sF
+prod_shots: BF99sF
 ---
 
 Hedda Gabler, the sophisticated daughter of an aristocratic general, has returned from her honeymoon with the somewhat less sophisticated Jorgen Tesman, a 14th Century Domestic Crafts Specialist. As they settle into their new home, the reappearance of Tesman's academic rival and Hedda's old flame, Ejlbert Lovborg throws their lives into disarray. Jealousy, blackmail and manipulation soon ensue as secrets are uncovered and lies unspun, culminating in the play's dramatic conclusion.

--- a/_shows/10_11/hymns.md
+++ b/_shows/10_11/hymns.md
@@ -30,7 +30,7 @@ assets:
 
 published: true
 
-smugmug: JCB2Hf
+prod_shots: JCB2Hf
 ---
 
 Four men reunite to mourn the loss of a close friend, but time has had a corrosive effect on this once tight-knit bunch. From beneath their surface bravura, a brooding animosity emerges. Their struggle to deal with grief and guilt brings them to a breaking point where the truth lays waiting.

--- a/_shows/10_11/normal.md
+++ b/_shows/10_11/normal.md
@@ -32,7 +32,7 @@ assets:
 
 published: true
 
-smugmug: ftZrLS
+prod_shots: ftZrLS
 ---
 
 "It seemed to me that the chill he had placed in my soul had finally thawed. I had not reckoned on feeling that chill again so soon…”

--- a/_shows/10_11/orphans.md
+++ b/_shows/10_11/orphans.md
@@ -38,7 +38,7 @@ assets:
 
 published: true
 
-smugmug: 7hRj7P
+prod_shots: 7hRj7P
 ---
 
 ‘I hate violence. It makes me cry. Always has…’

--- a/_shows/10_11/rope.md
+++ b/_shows/10_11/rope.md
@@ -60,7 +60,7 @@ assets:
 
 published: true
 
-smugmug: DGwFxc
+prod_shots: DGwFxc
 ---
 
 Brandon wants excitement and little cares how he gets it. With the help of his companion Granillo, he strangles a fellow student and deposits the body in a wooden chest. To celebrate this ‘perfect murder’, they invite some acquaintances (including the victim’s father) round to a party with the chest and its gruesome contents serving as a dining table. But Cadell is suspicious from the start of the evening...

--- a/_shows/10_11/smile.md
+++ b/_shows/10_11/smile.md
@@ -28,7 +28,7 @@ assets:
 
 published: true
 
-smugmug: BkNmfB
+prod_shots: BkNmfB
 ---
 
 A haunted war photographer hides at the end of a deserted fairground pier, surrounded only by her collection of postcards and memories of the Bosnian war zone.

--- a/_shows/10_11/the_laramie_project.md
+++ b/_shows/10_11/the_laramie_project.md
@@ -19,7 +19,6 @@ cast:
   - name: Dave Porter
   - name: Andy Routledge
   - name: Fran Rylands
-  - name: Izzy Scrimshire
   - name: Sophia Stanley
   - name: Weston Twardowski
 
@@ -35,7 +34,7 @@ assets:
 
 published: true
 
-smugmug: hWS9Mn
+prod_shots: hWS9Mn
 ---
 
 Laramie Wyoming. October 7th, 1998. A gay university student is found tied to a fence in an isolated field, beaten and left for dead - purely because of his sexuality. Matthew Shepard's abduction by two of the local boys created a media firestorm that spanned the globe, and inspired a generation to fight against intolerance.

--- a/_shows/10_11/the_lonesome_west.md
+++ b/_shows/10_11/the_lonesome_west.md
@@ -25,5 +25,5 @@ assets:
   - type: poster
     image: the_lonesome_west_2011.jpg
 
-smugmug: gSSjXh
+prod_shots: gSSjXh
 ---

--- a/_shows/10_11/this_wide_night.md
+++ b/_shows/10_11/this_wide_night.md
@@ -26,7 +26,7 @@ assets:
 
 published: true
 
-smugmug: d5RBFx
+prod_shots: d5RBFx
 ---
 
 On her release from prison, Lorraine heads straight to Marie's.

--- a/_shows/11_12/a_midsummer_night_s_dream.md
+++ b/_shows/11_12/a_midsummer_night_s_dream.md
@@ -72,7 +72,7 @@ assets:
   - type: poster
     image: a_midsummer_nights_dream_2011-12.jpg
 
-smugmug: BLFMXP
+prod_shots: BLFMXP
 ---
 
 Four lovers, six amateur actors and a gathering of spirits move through a wild forest one night. Around them nature itself is turned on its head as the King and Queen of the Fairies face-off. The moon watches on.

--- a/_shows/11_12/abigails_party.md
+++ b/_shows/11_12/abigails_party.md
@@ -32,7 +32,7 @@ assets:
   - type: poster
     image: abigails_party_2011-12.jpg
 
-smugmug: 46ngMs
+prod_shots: 46ngMs
 ---
 It’s 1977. The record player is rolling and the fibre light illuminates a crowded living room. Trapped in stifling suburbia and confrontational, dead end marriages, five neighbours, who have little more in common than geographic proximity, get together, get drunk and get increasingly disorderly. Meanwhile, Abigail is holding her own party next door.
 

--- a/_shows/11_12/all_my_sons.md
+++ b/_shows/11_12/all_my_sons.md
@@ -32,7 +32,7 @@ crew:
     name: Joseph Heil
   - name: Tessa Denney
 
-smugmug: s73C2d
+prod_shots: s73C2d
 ---
 
 Ohio, August, 1947. Joe Keller, a middle-aged businessman, sits in his garden with his family and neighbours, relaxing in his little piece of the American Dream. But the ghosts of his past are circling, ready to bring his world crashing around his ears. Arthur Miller's first classic brims with tension, poetry and emotional intensity.

--- a/_shows/11_12/be_my_baby.md
+++ b/_shows/11_12/be_my_baby.md
@@ -32,7 +32,7 @@ assets:
     image: be_my_baby_poster.jpg
 published: true
 
-smugmug: gwCnzK
+prod_shots: gwCnzK
 ---
 
 Set in a Mother and Baby Home in 1964, Be My Baby follows a 19 and unmarried Mary Adams who has fallen pregnant. Forced to go to the home by her mother, Mary along with the other girls, has to cope with the shame of her situation and the dawning realisation that her baby will be taken away and given up for adoption whether she likes it or not. Despite the hard hitting nature of the play, the youthfulness and positive spirit of the girls is echoed in the 1960s girl-group music which they sing along to.

--- a/_shows/11_12/bed.md
+++ b/_shows/11_12/bed.md
@@ -55,7 +55,7 @@ assets:
     filename: bed_programme.pdf
     title: Programme
 
-smugmug: ZJCjTC
+prod_shots: ZJCjTC
 ---
 
 

--- a/_shows/11_12/bed_lakeside.md
+++ b/_shows/11_12/bed_lakeside.md
@@ -48,11 +48,11 @@ crew:
   - role: Lighting Designer
     name: Matt Leventhall
   - role: Set Construction
-    name: Chelsea Jayne Wright  
+    name: Chelsea Jayne Wright
   - role: Set Construction
-    name: Gareth Morris  
+    name: Gareth Morris
   - role: Set Construction
-    name: Nick Stevenson  
+    name: Nick Stevenson
   - role: Make Up Artist
     name: Emily Heaton
 
@@ -63,7 +63,7 @@ assets:
     filename: bed_lakeside_programme.pdf
     title: Programme
 
-smugmug: tBcWnN
+prod_shots: tBcWnN
 ---
 
 

--- a/_shows/11_12/caddy_come_home.md
+++ b/_shows/11_12/caddy_come_home.md
@@ -8,7 +8,7 @@ venue: New Theatre
 date_start: 2012-06-05
 date_end: 2012-06-08
 
-smugmug: CT6DNv
+prod_shots: CT6DNv
 
 assets:
   - type: poster

--- a/_shows/11_12/charley_s_aunt.md
+++ b/_shows/11_12/charley_s_aunt.md
@@ -52,7 +52,7 @@ assets:
   - type: poster
     image: charleys_aunt_poster.jpg
 
-smugmug: mMFMrF
+prod_shots: mMFMrF
 ---
 
 Oxford University, 1892. The imminent arrival of Charley’s Aunt Donna Lucia, from Brazil, provides the perfect excuse for Charley and Jack to invite their young ladies to meet her. But when her visit is seemingly postponed, they persuade their eccentric friend Lord Fancourt Babberly to impersonate her. All is going well, until the real Aunt arrives…

--- a/_shows/11_12/closer.md
+++ b/_shows/11_12/closer.md
@@ -38,7 +38,7 @@ assets:
   - type: poster
     image: closer_2011-12.jpg
 
-smugmug: wfjW9W
+prod_shots: wfjW9W
 ---
 
 Lying is the most fun a girl can have without taking her clothes off, but it's better if they do. Described as a love story for adults, 'Closer' follows the vicious conflict between Dan and Larry as they battle for the affections of Alice and Anna.

--- a/_shows/11_12/faust_is_dead.md
+++ b/_shows/11_12/faust_is_dead.md
@@ -69,7 +69,7 @@ assets:
     image: faust-is-dead-programme-6.jpg
     page: 6
 
-smugmug: gZXJhk
+prod_shots: gZXJhk
 ---
 
 Elena announces ‘the Death of Man’ live on Letterman’s TV show. Pete can’t cope with the world without the comfort of a screen to frame it. The pair meet and find reality in a twisted world of disturbing social media. Both funny and brutal in equal measure. #isanythingrealanymore?

--- a/_shows/11_12/freshers_fringe.md
+++ b/_shows/11_12/freshers_fringe.md
@@ -8,7 +8,7 @@ date_start: 2011-10-20
 date_end: 2011-10-22
 venue: New Theatre
 
-smugmug: x6s4R2
+prod_shots: x6s4R2
 
 
 assets:

--- a/_shows/11_12/innocent_infidelity.md
+++ b/_shows/11_12/innocent_infidelity.md
@@ -83,7 +83,7 @@ assets:
     image: innocent-infidelity-programme-6.jpg
     page: 6
 
-smugmug: DnKhwP
+prod_shots: DnKhwP
 ---
 
 Reg is sleeping with Julia behind Hilary’s back but he’s doing nothing wrong. Julia only exists in his imagination. She is literally his dream woman. So, when Reg comes home one night to find Julia in his house, speaking to Hilary, his world is plunged into chaos and confusion.

--- a/_shows/11_12/look_back_in_anger.md
+++ b/_shows/11_12/look_back_in_anger.md
@@ -30,7 +30,7 @@ assets:
   - type: poster
     image: look_back_in_anger_2011-12.jpg
 
-smugmug: MZ97ds
+prod_shots: MZ97ds
 ---
 ‘I learnt at an early age what it was to be angry – angry and helpless.’
 

--- a/_shows/11_12/macbeth.md
+++ b/_shows/11_12/macbeth.md
@@ -56,7 +56,7 @@ assets:
   - type: poster
     image: macbeth_poster.jpg
 
-smugmug: 3mLjwg
+prod_shots: 3mLjwg
 ---
 
 A story of greed, ambition, desire and murder. The monotony of the 21st century office is soon disturbed as an ambitious Macbeth usurps and assassinates in his struggle for boardroom supremacy. Spurred on by encounters with the superstitious staff and the whispers of his ruthless wife, the established order is plunged into unknown chaos. This contemporary performance fuses modernity with the original text to present Shakespeare's classic reinvented.

--- a/_shows/11_12/rosencrantz_guildenstern_are_dead.md
+++ b/_shows/11_12/rosencrantz_guildenstern_are_dead.md
@@ -54,5 +54,5 @@ assets:
   - type: poster
     image: rosencrantz_and_guildenstern_are_dead_poster.jpg
 
-smugmug: 52cPmm
+prod_shots: 52cPmm
 ---

--- a/_shows/11_12/the_39_steps.md
+++ b/_shows/11_12/the_39_steps.md
@@ -34,7 +34,7 @@ assets:
   - type: poster
     image: the_39_steps_poster.jpg
 
-smugmug: H4XNfz
+prod_shots: H4XNfz
 ---
 
 When a mysterious spy is murdered in his apartment, Richard Hannay embarks on a quest to clear his name and save the country. Encountering over a hundred characters (all portrayed by only four performers), this fast-paced, comedic adaptation of Hitchcock’s classic both charms and excites.

--- a/_shows/11_12/the_beauty_queen_of_leenane.md
+++ b/_shows/11_12/the_beauty_queen_of_leenane.md
@@ -20,7 +20,7 @@ assets:
   - type: poster
     image: the_beauty_queen_of_leenane_poster.jpg
 
-smugmug: MLs3Sn
+prod_shots: MLs3Sn
 ---
 
 In rural Ireland, a manipulative elderly mother attempts to sabotage her daughter's first and last chance for love, driving her to desperate and brutal extremes. With a rare ability to provoke laughter in the darkest of moments, this biting black comedy perfectly balances the fine line between horror and hilarity.

--- a/_shows/11_12/the_gut_girls.md
+++ b/_shows/11_12/the_gut_girls.md
@@ -35,7 +35,7 @@ assets:
   - type: poster
     image: the_gut_girls_2011-12.jpg
 
-smugmug: 8wC2fv
+prod_shots: 8wC2fv
 ---
 
 Loud, bawdy and brash, the girls who work in the gutting sheds of Deptford’s Cattle Market enjoy life despite hanging from the bottom rung of the social ladder. Lady Helena believes it is her duty to improve their morals and make them ladies. The girls don’t necessarily agree.

--- a/_shows/11_12/the_history_boys.md
+++ b/_shows/11_12/the_history_boys.md
@@ -48,7 +48,7 @@ assets:
   - type: poster
     image: the_history_boys_poster.jpg
 
-smugmug: f5rCtk
+prod_shots: f5rCtk
 ---
 
 Alan Bennett’s ‘The History Boys’ is a funny, intelligent and provocative drama set in 1980s Sheffield, that tracks eight boys preparing for their Oxbridge entrance exams. It explores conflicting values about education, sexuality and social constructions, encompassing musical and theatrical elements to provide both a poignant and truly entertaining production.

--- a/_shows/11_12/the_hothouse.md
+++ b/_shows/11_12/the_hothouse.md
@@ -36,7 +36,7 @@ assets:
   - type: poster
     image: the_hothouse_poster.jpg
 
-smugmug: 9L7cvg
+prod_shots: 9L7cvg
 
 ---
 

--- a/_shows/11_12/the_off_white_horse.md
+++ b/_shows/11_12/the_off_white_horse.md
@@ -36,5 +36,5 @@ assets:
   - type: poster
     image: the_off_white_horse_poster.jpg
 
-smugmug: MqcWrs
+prod_shots: MqcWrs
 ---

--- a/_shows/11_12/too_far_away.md
+++ b/_shows/11_12/too_far_away.md
@@ -34,7 +34,7 @@ assets:
   - type: poster
     image: too_far_away_poster.jpg
 
-smugmug: 8tcnFz
+prod_shots: 8tcnFz
 ---
 
 The Home Front in 1917, the horrors of a dugout in France, and an old man sitting on a War Memorial 40 years later. Riddled with bleak humour and heart-wrenching pathos, ‘Too Far Away’ explores the ways that individual lives were ripped apart by one of the greatest tragedies ever to befall mankind

--- a/_shows/12_13/a_clockwork_orange.md
+++ b/_shows/12_13/a_clockwork_orange.md
@@ -54,7 +54,7 @@ assets:
   - type: poster
     image: a_clockwork_orange_poster.jpg
 
-smugmug: LXKVTq
+prod_shots: LXKVTq
 
 ---
 

--- a/_shows/12_13/black_comedy.md
+++ b/_shows/12_13/black_comedy.md
@@ -61,7 +61,7 @@ assets:
   - type: poster
     image: black_comedy_poster.jpg
 
-smugmug: QjMHKp
+prod_shots: QjMHKp
 ---
 
 Black comedy is a farce set entirely in a pitch black flat, as a power cut leaves the audience the only ones not groping in the dark. With soft drinks mixed up with alcohol bottles and priceless antiques left lying around, the power cut quickly leads to chaos. Blind chaos.

--- a/_shows/12_13/boeing_boeing.md
+++ b/_shows/12_13/boeing_boeing.md
@@ -80,7 +80,7 @@ assets:
   - type: poster
     image: boeing_boeing_poster.jpg
 
-smugmug: mFhRGn
+prod_shots: mFhRGn
 ---
 
 Bernard has got three fiancées. They’re all airhostesses for different airlines and their timetables work out perfectly so none of them realise the others exist. One day an old friend turns up out of the blue and things couldn’t be jollier. But severe weather plays havoc with both the airlines’ and Bernard’s timetables. Chaos and hilarity, inevitably, ensue

--- a/_shows/12_13/east.md
+++ b/_shows/12_13/east.md
@@ -59,7 +59,7 @@ crew:
     name: Dimitrios Darzentas
   - role: Photography
     name: Nick Barker
-smugmug: dvVPZh
+prod_shots: dvVPZh
 
 assets:
   - type: poster

--- a/_shows/12_13/educating_rita.md
+++ b/_shows/12_13/educating_rita.md
@@ -52,7 +52,7 @@ assets:
   - type: poster
     image: educating_rita_poster.jpg
 
-smugmug: 4PNWCh
+prod_shots: 4PNWCh
 ---
 
 Rita is a 26 year-old hairdresser with a desire to ‘learn everything’ and Frank is a fifty-something lecturer who has fallen out of love with his job, his wife and just about everything except his hoard of whisky hidden within his bookshelves. A tale of a working class, Liverpool woman’s hunger for education, and both the humorous and serious effects higher education can have.

--- a/_shows/12_13/eight.md
+++ b/_shows/12_13/eight.md
@@ -35,6 +35,6 @@ assets:
   - type: poster
     image: eight_2012-13.jpg
 
-smugmug: ZHGQTg
+prod_shots: ZHGQTg
 ---
 Are we a generation that has lost the faculty of faith; societal refugees, struggling to muster belief in ourselves and the world around us? Eight presents six compelling monologues exploring what happens growing up in a world where everything has become acceptable.

--- a/_shows/12_13/freshers_fringe.md
+++ b/_shows/12_13/freshers_fringe.md
@@ -26,7 +26,7 @@ assets:
   - type: poster
     image: freshers_fringe_2012_poster.jpg
 
-smugmug: pmLRD9
+prod_shots: pmLRD9
 ---
 
 A selection of scenes and sketches performed by the rising starts of The Nottingham New Theatre.

--- a/_shows/12_13/jack_aged_five_and_a_half.md
+++ b/_shows/12_13/jack_aged_five_and_a_half.md
@@ -31,5 +31,5 @@ assets:
   - type: poster
     image: jack_aged_five_and_a_half_poster.jpg
 
-smugmug: B3VXLC
+prod_shots: B3VXLC
 ---

--- a/_shows/12_13/jerusalem.md
+++ b/_shows/12_13/jerusalem.md
@@ -11,7 +11,7 @@ date_end: 2012-12-08
 
 tour:
 - venue: NSDF 2013
-- date_start: 
+- date_start:
 - date_end:
 - notes: Buzz Goodbody Student Director’s Award  |  Peter Bradley For Jerusalem, Acting (Supporting Role)  |  Jake Leonard for Wesley in Jerusalem, Acting (Company)  |  Jerusalem, Design  |  Jessica Courtney for Jerusalem
 
@@ -91,7 +91,7 @@ assets:
   - type: poster
     image: jerusalem_poster.jpg
 
-smugmug: Btr98g
+prod_shots: Btr98g
 ---
 
 Join infamous scumbag Johnny Rooster Byron and a host of other outcasts as they fight back against their local village council. It’s the day of the annual village fete and Johnny’s just been evicted from his dilapidated caravan in the middle of the woods. Vivid characters. Fast-paced, anarchic dialogue. A woodland set complete with a real smashed up caravan. What’s not to love?!

--- a/_shows/12_13/little_red.md
+++ b/_shows/12_13/little_red.md
@@ -42,7 +42,7 @@ assets:
   - type: poster
     image: little_red_poster.jpg
 
-smugmug: RvnCQ5
+prod_shots: RvnCQ5
 ---
 
 A unique devised performance. The process began with talking about the symbolism of childhood innocence and sexual awakening within ‘Little Red Riding Hood’ – this developed into improvisations, scripting and a complete original play. The production presents the story of Alice, a modern thirteen year old girl, who strives to leave the path of childish ignorance. The modern world interweaves with the traditional fairytale creating a ghostly parallel of Alice’s experience. Be entertained by a play which harnesses an original style – including ensemble sequences, singing and stylised characterisations – and will move you and make you laugh as we discover that reality does not always guarantee happy endings.

--- a/_shows/12_13/lysistrata.md
+++ b/_shows/12_13/lysistrata.md
@@ -76,7 +76,7 @@ crew:
   - role: Production Assistant
     name: Joseph Heil
 
-smugmug: jnNkKq
+prod_shots: jnNkKq
 ---
 
 The ancient world is gripped by a seemingly interminable war. With the men of Athens all serving in the forces, the women of the city can take no more. In secret, they meet with the enemy women and form a pact. The battle moves into the bedroom. No sex for the men - unless the women get peace. Lysistrata is the original battle of the sexes and its themes of feminism, power and politics are as relevant now as they were in ancient Greece.

--- a/_shows/12_13/mary_shelley_s_frankenstein.md
+++ b/_shows/12_13/mary_shelley_s_frankenstein.md
@@ -115,7 +115,7 @@ assets:
   - type: poster
     image: frankenstein_poster.jpg
 
-smugmug: S4pKW6
+prod_shots: S4pKW6
 
 ---
 

--- a/_shows/12_13/me_as_a_penguin.md
+++ b/_shows/12_13/me_as_a_penguin.md
@@ -54,7 +54,7 @@ assets:
     image: me_as_a_penguin_poster.jpg
 published: true
 
-smugmug: GGpqn2
+prod_shots: GGpqn2
 ---
 
 Stitch is looking to gain some direction in his life by visiting his sister and exploring the very exciting gay scene of Hull. What results is an obsessive crush on a man that works in the local aquarium and Stitch stealing a baby penguin. Brilliantly funny, emotionally moving, ‘Me, As Penguin’ is a unique, witty and northern comedy.

--- a/_shows/12_13/mercury_fur.md
+++ b/_shows/12_13/mercury_fur.md
@@ -58,7 +58,7 @@ crew:
 
 tour:
 - venue: NSDF 2013
-- date_start: 
+- date_start:
 - date_end:
 - notes: Acting Commendation  |  Laura Gallop for Naz In Mercury Fur
 
@@ -67,7 +67,7 @@ assets:
   - type: poster
     image: mercury_fur_poster.jpg
 
-smugmug: m4KPV7
+prod_shots: m4KPV7
 ---
 
 Set in London, in the not so distant future, where gangs prevail and memory has been wiped by the consumption of hallucinogenic butterflies, brothers Elliot and Darren survive by organising ‘parties’ where their clients’ most sadistic fantasies are realised. But it soon becomes clear that the success of one particular party will guarantee not just their safety, but their salvation.

--- a/_shows/12_13/night_mother.md
+++ b/_shows/12_13/night_mother.md
@@ -34,7 +34,7 @@ assets:
   - type: poster
     image: night_mother_poster.jpg
 
-smugmug: FTpG92
+prod_shots: FTpG92
 ---
 
 Jessie's father is dead, her absent son is a petty thief and following the breakup of her loveless marriage she has moved back in with her mother. Helpless and tired, one evening she asks for her father's service revolver and calmly announces that she intends to kill herself. A tragic two-hander for a talented female duo.

--- a/_shows/12_13/ninteen_eighty_four.md
+++ b/_shows/12_13/ninteen_eighty_four.md
@@ -55,7 +55,7 @@ assets:
   - type: poster
     image: 1984_poster.jpg
 
-smugmug: ZMVCKk
+prod_shots: ZMVCKk
 ---
 
 War is peace. Freedom is Slavery. Ignorance is strength. Orwell's classic novel follows Winston and Julia as they face the perils of rebelling against Big Brother's totalitarian regime. Set in an industrial scaffolding amphitheatre, controlled by the eight-strong cast, a relationship is brutally ripped apart, a man tortured and reality becomes unknowable.

--- a/_shows/12_13/no_exit.md
+++ b/_shows/12_13/no_exit.md
@@ -38,7 +38,7 @@ assets:
   - type: poster
     image: no_exit_poster.jpg
 
-smugmug: sqVqKs
+prod_shots: sqVqKs
 ---
 
 Three strangers are locked in a room together. This room is hell but instead of shackles, racks and fire there are only words, unwanted affection and troublesome pasts. By the end of this one act play, Garcin, Inez and Estelle are inseparable, however they all come to the same conclusion; hell is definitely other people!

--- a/_shows/12_13/osama_the_hero.md
+++ b/_shows/12_13/osama_the_hero.md
@@ -30,7 +30,7 @@ assets:
   - type: poster
     image: osama_the_hero_poster_cropped.jpg
 
-smugmug: gQdpgv
+prod_shots: gQdpgv
 
 ---
 

--- a/_shows/12_13/paradise_fringe.md
+++ b/_shows/12_13/paradise_fringe.md
@@ -26,7 +26,7 @@ crew:
   - role: Editing
     name: Alex Jamieson
 
-smugmug: 5j5PKS
+prod_shots: 5j5PKS
 
 assets:
   - type: poster

--- a/_shows/12_13/pub_quiz_is_life.md
+++ b/_shows/12_13/pub_quiz_is_life.md
@@ -60,7 +60,7 @@ assets:
   - type: poster
     image: pub_quiz_is_life_poster.jpg
 
-smugmug: p47xCL
+prod_shots: p47xCL
 ---
 
 When Lee returns to Hull after returning from a tour in Afghanistan, he joins his team mates for the local quiz. ‘My Dad’s a Drug Dealer’ have been losing for years to the teachers but Lee wants all that to change, and when he meets Melissa, who comes to Hull to regenerate the city he sees his chance to finally win. A murderous black comedy, set in Hull’s black economy, with too many questions and all the wrong answers.

--- a/_shows/12_13/red.md
+++ b/_shows/12_13/red.md
@@ -35,7 +35,7 @@ assets:
   - type: poster
     image: red_poster.jpg
 
-smugmug: b9rB8K
+prod_shots: b9rB8K
 ---
 
 It's 1958. Mark Rothko the legendary expressionist works alone in this Bowery Street studio, where he is joined by assistant Ken, a young emerging artist. As their work draws them closer together, Mark finds himself fighting for his artistic philosophies. What is art? What is creativity, violence, madness, sexuality and power? Above all what is our humanity worth?

--- a/_shows/12_13/stags_and_hens.md
+++ b/_shows/12_13/stags_and_hens.md
@@ -65,7 +65,7 @@ assets:
   - type: poster
     image: stags_and_hens_poster_cropped.jpg
 
-smugmug: FB65P2
+prod_shots: FB65P2
 
 ---
 

--- a/_shows/12_13/the_last_of_the_haussmans.md
+++ b/_shows/12_13/the_last_of_the_haussmans.md
@@ -39,7 +39,7 @@ assets:
   - type: poster
     image: the_last_of_the_haussmans_2012-13.jpg
 
-smugmug: mD6gXn
+prod_shots: mD6gXn
 ---
 
 Think you have a disfunctional family? Think again. The Haussmann's relationships are challenged by addiction, infatuation, resentment and free love. This play is a savage yet heartwarming portrait of the love-hate relationships within a contemporary family

--- a/_shows/12_13/the_memory_of_water.md
+++ b/_shows/12_13/the_memory_of_water.md
@@ -10,7 +10,7 @@ date_end: 2012-11-10
 
 tour:
 - venue: NSDF 2013
-- date_start: 
+- date_start:
 - date_end:
 - notes: Acting Commendation  |  Rosanna Stoker for Mary in The Memory Of Water
 
@@ -51,7 +51,7 @@ assets:
   - type: poster
     image: memory_of_water_poster.jpg
 
-smugmug: pkW8Vv
+prod_shots: pkW8Vv
 ---
 
 "Someone dies, you drink whiskey. It's normal, it's a sedative, it's what normal people do at abnormal times." Three sisters; Teresa, Mary and Catherine, come together before their mother's funeral, each haunted by their own demons, each possessing different memories of the same events. Darkly comic, the play shows that even in traumatic times, humour can be found anywhere.

--- a/_shows/12_13/the_pillowman.md
+++ b/_shows/12_13/the_pillowman.md
@@ -56,7 +56,7 @@ crew:
   - role: Photographer
     name: Frazer Roberts
 
-smugmug: DhnJMK
+prod_shots: DhnJMK
 
 assets:
   - type: poster

--- a/_shows/12_13/the_proposal_the_bear.md
+++ b/_shows/12_13/the_proposal_the_bear.md
@@ -44,7 +44,7 @@ assets:
     image: the_proposal_the_bear_poster.jpg
 
 
-smugmug: b2NgXt
+prod_shots: b2NgXt
 ---
 
 ### The Proposal

--- a/_shows/12_13/the_woman_who_cooked_her_husband.md
+++ b/_shows/12_13/the_woman_who_cooked_her_husband.md
@@ -37,7 +37,7 @@ assets:
   - type: poster
     image: the_woman_who_cooked_her_husband_poster.jpg
 
-smugmug: 5ccxNm
+prod_shots: 5ccxNm
 ---
 
 A play of murderous hunger and creeping revenge. Kenneth battles against two of man’s most grave obsessions – sex and food. We follow Kenneth’s yo-yo ride between his wife, Hilary, who provides him with the most lustful meals, and his mistress, Laura, who gives him the most scrumsious sex. Three years after the divorce, Hilary invites Laura and Kenneth round for a celebratory meal. With a hungry look at Kenneth, Hilary informs her guests that the main course will be a surprise. Tonight, sweet revenge is sure to be on the menu.

--- a/_shows/12_13/voice_without_words.md
+++ b/_shows/12_13/voice_without_words.md
@@ -25,7 +25,7 @@ assets:
   - type: poster
     image: voice_without_words_poster.jpg
 
-smugmug: jsqxv7
+prod_shots: jsqxv7
 ---
 
 A great storm has passed. An old clown walks the barren wasteland, desperate and alone. He is haunted by dreams of a long forgotten life, the ghosts of a thousand people walk beside him. He cannot speak. But in his silence he seeks to entertain and spread his message of hope. He cannot be the last. There must be some humanity left…

--- a/_shows/12_13/wild_west_end.md
+++ b/_shows/12_13/wild_west_end.md
@@ -34,7 +34,7 @@ photos:
   - type: people
     image: wild_west_end_people.jpg
 
-smugmug: 9CnkkD
+prod_shots: 9CnkkD
 
 ---
 

--- a/_shows/13_14/back_to_oblivion.md
+++ b/_shows/13_14/back_to_oblivion.md
@@ -35,7 +35,7 @@ crew:
   - role: Technical Operator
     name: Joanne Blunt
 
-smugmug: 42n8wt
+prod_shots: 42n8wt
 
 assets:
   - type: poster

--- a/_shows/13_14/betrayal.md
+++ b/_shows/13_14/betrayal.md
@@ -54,7 +54,7 @@ crew:
   - role: Photography
     name: Erina Bogoeva
 
-smugmug: 4Rzt7j
+prod_shots: 4Rzt7j
 
 assets:
   - type: poster

--- a/_shows/13_14/blackbird.md
+++ b/_shows/13_14/blackbird.md
@@ -40,7 +40,7 @@ crew:
   - role: Photography
     name: Nick Barker
 
-smugmug: s4QTx7
+prod_shots: s4QTx7
 
 assets:
   - type: poster

--- a/_shows/13_14/concrete_boots.md
+++ b/_shows/13_14/concrete_boots.md
@@ -40,7 +40,7 @@ crew:
   - role: Photography
     name: Erina Bogoeva
 
-smugmug: STZnZt
+prod_shots: STZnZt
 
 assets:
   - type: poster

--- a/_shows/13_14/conviction.md
+++ b/_shows/13_14/conviction.md
@@ -32,7 +32,7 @@ assets:
   - type: poster
     image: conviction_poster.jpg
 
-smugmug: X5XMTr
+prod_shots: X5XMTr
 
 ---
 A comic tragedy, Conviction tells the story of Zane and Javan: two unhinged cellmates who've lost their memory. Forced by circumstance to cooperate, their sanity tested as they both desperately try to remember who they are, and ultimately why they deserve punishment. But do they really, truly want to remember?

--- a/_shows/13_14/customs.md
+++ b/_shows/13_14/customs.md
@@ -41,7 +41,7 @@ assets:
   - type: poster
     image: customs_poster.jpg
 
-smugmug: qHV3rs
+prod_shots: qHV3rs
 
 ---
 

--- a/_shows/13_14/dr_faustus.md
+++ b/_shows/13_14/dr_faustus.md
@@ -50,7 +50,7 @@ crew:
   - role: Assistant to Publicity Designer
     name: Emily Zinkin
 
-smugmug: FZgKb4
+prod_shots: FZgKb4
 
 assets:
   - type: poster

--- a/_shows/13_14/equus.md
+++ b/_shows/13_14/equus.md
@@ -72,7 +72,7 @@ assets:
   - type: poster
     image: equus_poster.jpg
 
-smugmug: sQvgwk
+prod_shots: sQvgwk
 ---
 
 Equus took critics and public alike by storm and has gone on to become a modern classic, Peter Shaffer depicts the story of a deranged youth who blinds six horses with a spike. Through a psychiatrist's analysis of the events, Shaffer creates a chilling portrait of how materialism and convenience have killed our capacity for worship and passion and, consequently, our capacity for pain. Rarely has a playwright created an atmosphere and situation that so harshly pinpoints the spiritual and mental decay of modern man. With passionate monologue combined with a thrilling exploration of physicality, Equus is a play not to be missed.

--- a/_shows/13_14/fox_finder.md
+++ b/_shows/13_14/fox_finder.md
@@ -51,7 +51,7 @@ assets:
   - type: poster
     image: fox_finder_poster.jpg
 
-smugmug: SGZvsM
+prod_shots: SGZvsM
 
 ---
 Without Man, the Fox will Rule. Dawn King’s tense and atmospheric parable sees William Bloor, a Foxfinder religiously committed to the discovery and destruction of England’s greatest threat, investigate the farm of a recently bereaved couple, Judith and Samuel Covey, for potential infestation and even collaboration.

--- a/_shows/13_14/habeas_corpus.md
+++ b/_shows/13_14/habeas_corpus.md
@@ -67,7 +67,7 @@ assets:
     image: habeas_corpus_poster.jpg
 
 
-smugmug: vK28q8
+prod_shots: vK28q8
 ---
 
 A festive end to the season with a hilarious, quick-paced farce by Alan Bennett. It tells the story of a family and their friends, all of whom are driven by one key desire – sex – but a number of mistaken identities and awkward encounters ensure things don’t quite go as planned.

--- a/_shows/13_14/kiss_me_like_you_mean_it.md
+++ b/_shows/13_14/kiss_me_like_you_mean_it.md
@@ -42,7 +42,7 @@ crew:
   - role: Stage Manager
     name: Dave Hanks
 
-smugmug: cR5dxw
+prod_shots: cR5dxw
 
 assets:
   - type: poster

--- a/_shows/13_14/krapps_last_tape.md
+++ b/_shows/13_14/krapps_last_tape.md
@@ -38,7 +38,7 @@ crew:
   - role: Photographer
     name: Nick Barker
 
-smugmug: jz7XxB
+prod_shots: jz7XxB
 
 assets:
   - type: poster

--- a/_shows/13_14/letting_go.md
+++ b/_shows/13_14/letting_go.md
@@ -43,7 +43,7 @@ assets:
   - type: poster
     image: letting_go_poster.jpg
 
-smugmug: RChW6m
+prod_shots: RChW6m
 
 comment: "Video here:  https://www.youtube.com/watch?v=Ltw1tYemf6A&app=desktop"
 ---

--- a/_shows/13_14/molly_sweeny.md
+++ b/_shows/13_14/molly_sweeny.md
@@ -100,7 +100,7 @@ assets:
   - type: poster
     image: molly_sweeney_poster.jpg
 
-smugmug: q5TP5z
+prod_shots: q5TP5z
 
 ---
 

--- a/_shows/13_14/queen_b.md
+++ b/_shows/13_14/queen_b.md
@@ -47,7 +47,7 @@ assets:
     page: 2
     image: queen_b_pub_5.jpg
 
-smugmug: WGPL3j
+prod_shots: WGPL3j
 ---
 
 Dan is lost. Everything hasn't quite turned out how he would have liked and he is afraid the most of his life has already passed him by. When he meets Amy, a completely unfiltered and free-spirited 19-year-old girl with a fractured family life, he finds a way to live again, rebelling against everything he holds dear. But how does a 40-year-old man go about meeting a 19-year-old girl? And can the repercussions from their first meeting ever really go away?

--- a/_shows/13_14/romeo_and_juliet.md
+++ b/_shows/13_14/romeo_and_juliet.md
@@ -104,7 +104,7 @@ crew:
   - role: Photographer
     name: unknown
 
-smugmug: 6DhKFZ
+prod_shots: 6DhKFZ
 
 assets:
   - type: poster

--- a/_shows/13_14/the_last_days_of_judas_iscariot.md
+++ b/_shows/13_14/the_last_days_of_judas_iscariot.md
@@ -68,7 +68,7 @@ assets:
   - type: poster
     image: judas_poster.jpg
 
-smugmug: Mn7LBT
+prod_shots: Mn7LBT
 
 ---
 Set in a place between Heaven and Hell, where Mother Teresa and Satan sit side-by-side, you have been summoned for jury duty to participate in the sentencing of history’s most notorious betrayer, Judas Iscariot. Fast-paced, witty and controversial ‘The Last Days of Judas Iscariot’ doesn’t settle for simplistic answers but rather explores the violent rupture of relationships between iconic figures in history. Not anti-Christian or anti-Catholic…but you’ll definitely fall in love with the anti-Christ.

--- a/_shows/13_14/the_pitchfork_disney.md
+++ b/_shows/13_14/the_pitchfork_disney.md
@@ -44,7 +44,7 @@ assets:
   - type: poster
     image: the_pitchfork_disney_poster.jpg
 
-smugmug: FHND75
+prod_shots: FHND75
 
 ---
 Twins Presley and Haley Stray live alone in a dilapidated flat in East London, passing the time by telling each other twisted stories and eating chocolate. Into this world comes the menacingly beautiful circus performer Cosmo Disney, and his nightmarish associate, Pitchfork Cavalier. This unexpected visit and its terrifying consequences will change the Strays forever.

--- a/_shows/13_14/the_rehearsal.md
+++ b/_shows/13_14/the_rehearsal.md
@@ -38,7 +38,7 @@ crew:
   - role: Photography
     name: Nick Barker
 
-smugmug: sHb6xL
+prod_shots: sHb6xL
 
 assets:
   - type: poster

--- a/_shows/13_14/titus_andronicus.md
+++ b/_shows/13_14/titus_andronicus.md
@@ -99,7 +99,7 @@ assets:
   - type: poster
     image: titus_andronicus_poster.jpg
 
-smugmug: tW92hS
+prod_shots: tW92hS
 
 ---
 

--- a/_shows/13_14/tribes.md
+++ b/_shows/13_14/tribes.md
@@ -56,7 +56,7 @@ assets:
   - type: poster
     image: tribes_poster.jpg
 
-smugmug: Gt964M
+prod_shots: Gt964M
 ---
 
 Billy’s fiercely intelligent and proudly unconventional family are their own tiny empire, with their own private language, jokes and rules. You can be as rude as you like, as possessive as you like, as critical as you like. Arguments are an expression of love. After all, you’d do anything for each other – wouldn’t you? But Billy, who is deaf, is one of the few who actually listens. Meeting Sylvia makes him finally want to be heard; can he get a word in edgeways?

--- a/_shows/14_15/a_midsummer_nights_dream.md
+++ b/_shows/14_15/a_midsummer_nights_dream.md
@@ -68,7 +68,7 @@ assets:
   - type: poster
     image: a_midsummer_nights_dream_lakeside.jpg
 
-smugmug: Dhcwp6
+prod_shots: Dhcwp6
 
 ---
 

--- a/_shows/14_15/infirmity.md
+++ b/_shows/14_15/infirmity.md
@@ -35,7 +35,7 @@ assets:
   - type: poster
     image: infirmity_poster.jpg
 
-smugmug: jDNnN5
+prod_shots: jDNnN5
 ---
 
 Connor and Charlotte have been together since university. Now in their early 30’s, they’re struggling to maintain their relationship, so have sought help from a psychotherapist: Peter. Through a series of flashbacks, Peter explores the couple’s past, and begins to uncover the potential contributing issues. However, all is not as it seems, and a dark secret is being kept that threatens to tear Connor and Charlotte apart…

--- a/_shows/14_15/lets_just_pretend.md
+++ b/_shows/14_15/lets_just_pretend.md
@@ -62,7 +62,7 @@ assets:
   - type: poster
     image: lets_just_pretend_poster.jpg
 
-smugmug: Lxr89p
+prod_shots: Lxr89p
 ---
 
 ‘Let’s Just Pretend’ follows the relationship of Caroline and Mark, from when they are sixteen to twenty eight. Caroline is ambitious and pragmatic alongside Mark’s love of imagination and together they flirt with the boundaries of reality. The audience watch their friendship and love blossom as they guide each other through teenage crises and real life trials. But as the play flashes forward and Mark moves further and further away from reality, Caroline wonders if he truly loves her or if he is just holding on the person she was when they were sixteen.

--- a/_shows/14_15/not_about_heroes.md
+++ b/_shows/14_15/not_about_heroes.md
@@ -46,7 +46,7 @@ assets:
   - type: poster
     image: not_about_heroes_poster.jpg
 
-smugmug: hn8nZP
+prod_shots: hn8nZP
 ---
 
 Edinburgh, July 1917. At Craiglockhart War Hospital for Nervous Disorders, Siegfried Sassoon crosses paths with Wilfred Owen. The former, arrogant and frustrated, has literary fame; the latter, diffident and traumatised, is completely unknown. Under Sassoon’s tutelage, Owen creates the most revered war poetry ever written, including Anthem for Doomed Youth and Dulce et Decorum Est. Fifteen years later, after a string of affairs and spiralling into depression, Sassoon looks back on their sixteen months of passion- passion that was for both their poetry and for each other. “I don’t know where either of us will go. But I’m glad I’m here, tonight, with you.”

--- a/_shows/14_15/old_times.md
+++ b/_shows/14_15/old_times.md
@@ -24,7 +24,7 @@ crew:
   - role: Poster Designer
     name: Max Miller
 
-smugmug: JHTfPQ
+prod_shots: JHTfPQ
 
 assets:
   - type: poster

--- a/_shows/14_15/open.md
+++ b/_shows/14_15/open.md
@@ -44,7 +44,7 @@ assets:
     filename: Open Poster Front.pdf
     title: Edinburgh Poster
 
-smugmug: 4VFmSk
+prod_shots: 4VFmSk
 ---
 
 Sharp devised theatre peering through the cracks in modern Britain.

--- a/_shows/14_15/orphans.md
+++ b/_shows/14_15/orphans.md
@@ -42,7 +42,7 @@ assets:
   - type: poster
     image: orphans_poster.jpg
 
-smugmug: r5bkP7
+prod_shots: r5bkP7
 ---
 
 Helen and her husband Danny are celebrating the news that Helen is newly pregnant with their second child with a quiet night in, but are interrupted by Helen's brother Liam, who arrives covered in blood claiming to have found a young man who has been stabbed on the street. However when Liam's account of the event begins to change under questioning, suspicions are aroused followed by increasing concern that he may have been more involved than first thought. A commentary on the extreme violence in urban areas, the question is - how far you would go for your family?

--- a/_shows/14_15/overspill.md
+++ b/_shows/14_15/overspill.md
@@ -52,7 +52,7 @@ assets:
   - type: poster
     image: overspill_poster.jpg
 
-smugmug: 2fMH2s
+prod_shots: 2fMH2s
 ---
 
 Overspill is a play set in Bromley revolving around Baron, Potts and Finch - three 20 year old mates who decide to tell the story of their usual Friday night out filled with booze, burgers, bouncers, birds and banter. However, things take an unexpected turn when a bomb explodes in McDonalds and interrupts their comfortable routine. As more explosions tear their beloved hometown apart, tensions rise in the town as a vigilante state of mind takes hold, and for the lads, who began the weekend with such bravado, things are about to come to a violent end.

--- a/_shows/14_15/rhinoceros.md
+++ b/_shows/14_15/rhinoceros.md
@@ -80,7 +80,7 @@ assets:
   - type: poster
     image: rhinoceros_poster_3.jpg
 
-smugmug: Tz3wCC
+prod_shots: Tz3wCC
 ---
 
 Written by one of the founding fathers of the ‘the Theatre of the Absurd’ / ‘Rhinoceros’ follows Berenger / a disenfranchised and disillusioned anti-hero / as he refuses to change whilst the rest of the characters turn into rhinoceroses. A dark / dystopian / satirical phase / ‘Rhinoceros’ is fundamentally a play about conformity and the cult of opinion. However / the play touches on many ideas / such as the meaningless of language / the ridiculousness of everyday convention and alienation. This chilling representation of humanity attacks the arrogance of our everyday moral convictions.

--- a/_shows/14_15/the_glass_menagerie.md
+++ b/_shows/14_15/the_glass_menagerie.md
@@ -64,7 +64,7 @@ assets:
   - type: poster
     image: the_glass_menagerie_poster.jpg
 
-smugmug: prJzNs
+prod_shots: prJzNs
 ---
 
 Life in St Louis, Missouri, during the Great Depression was not easy. Tom Wingfield knows this all too well as he shares his memories of that time. A young aspiring poet tethered by reality to a monotonous job in a shoe factory, Tom is obligated to financially support his mother, Amanda, and his emotionally unstable sister, Laura, after his father abandoned the family some years previously. Having spent her younger years in Blue Mountain being greeted by gentleman callers, Amanda becomes obsessed with finding Laura a husband. Driven to the edge by judgement and hopelessness, Tom must choose between the family he loves and the life he desires.

--- a/_shows/14_15/the_infant.md
+++ b/_shows/14_15/the_infant.md
@@ -62,7 +62,7 @@ assets:
   - type: poster
     image: the_infant_poster.jpg
 
-smugmug: XxgxsK
+prod_shots: XxgxsK
 ---
 
 They have a picture, a picture that could spell the destruction of civilised society. And it might have been drawn by a 4 year old child. Who’s telling the truth? What is the truth? And does the truth really matter any more?

--- a/_shows/14_15/the_ritual_slaughter_of_gorge_mastromas.md
+++ b/_shows/14_15/the_ritual_slaughter_of_gorge_mastromas.md
@@ -10,7 +10,7 @@ venue: New Theatre
 
 tour:
 - venue: NSDF 2015
-- date_start: 
+- date_start:
 - date_end:
 - notes: Won The Festgoers Award
 
@@ -73,7 +73,7 @@ assets:
   - type: poster
     image: ritual_slaughter_poster.jpg
 
-smugmug: rkQVgT
+prod_shots: rkQVgT
 ---
 
 If you could lie without flinching, corrupt without caring and succeed at all costs, how far would you go? How much would you make? An unrelenting attack on human nature, you must ask one simple question. Is it Goodness? Or Cowardice?

--- a/_shows/14_15/the_toyland_murders.md
+++ b/_shows/14_15/the_toyland_murders.md
@@ -11,7 +11,7 @@ venue: PAS, Trent Building
 
 tour:
 - venue: NSDF 2016
-- date_start: 
+- date_start:
 - date_end:
 
 cast:
@@ -71,7 +71,7 @@ assets:
   - type: poster
     image: the_toyland_murders_poster.jpg
 
-smugmug: BKLFFS
+prod_shots: BKLFFS
 ---
 
 When a series of mysterious murders hits downtown Toyland, it’s up to ragdoll Inspector Carmen McGraw and teddy bear Deputy Harvey B. Feltz to get to the bottom of it once and for all. Featuring hard-boiled wise-cracks, a line-up of colourful criminals and more murder outlines than you can shake a crow bar at, The Toyland Murders is a fast-paced family-friendly toybox puppet noir adventure unlike anything the New Theatre’s seen before.

--- a/_shows/14_15/women_of_troy.md
+++ b/_shows/14_15/women_of_troy.md
@@ -87,7 +87,7 @@ assets:
   - type: poster
     image: women_of_troy_poster.jpg
 
-smugmug: xdfV9r
+prod_shots: xdfV9r
 ---
 
 The Trojan War is over. All its men are dead, all its women's fate lie in the hands of their conquerors. In a prison, as the women await their fate, they struggle to keep alive their dignity, their humanity and their memories of a civilisation soon to be lost forever. Two thoughts keep them alive: to see their prince, Astyanax, survive to found a new Troy. And to see the punishment by death of the woman they blame for all their suffering, Helen.

--- a/_shows/15_16/a_view_from_the_bridge.md
+++ b/_shows/15_16/a_view_from_the_bridge.md
@@ -72,7 +72,7 @@ assets:
   - type: poster
     image: view_poster.jpg
 
-smugmug: RSgMvk
+prod_shots: RSgMvk
 ---
 
 Eddie Carbone is a longshoreman and straightforward man, with a strong sense of decency and honour. For Eddie, it’s a privilege to take in his wife’s cousins, straight off the boat from Italy. But as his niece begins to fall for one of them, it’s clear that it’s not just, as Eddie claims, that he’s too strange, too effeminate, too careless for her, but that something bigger, deeper is wrong, wrong inside Eddie, in a way that he can’t face. Something that threatens the happiness of their whole family. Arthur Miller’s tragic masterpiece, about the unravelling of a man who holds family and honour above all else, tackles sexuality, community and justice in an unnerving, powerful drama.

--- a/_shows/15_16/bull.md
+++ b/_shows/15_16/bull.md
@@ -12,7 +12,7 @@ assets:
   - type: poster
     image: bull.jpg
 
-cast: 
+cast:
  - role: Thomas
    name: Nick Gill
  - role: Tony
@@ -36,7 +36,7 @@ crew:
  - role: Poster Designer
    name: Harry Bradley
 
-smugmug: rGrN9V
+prod_shots: rGrN9V
 ---
 
 Three employees, two jobs, one boss, and a cutthroat attitude. Mike Bartlett’s Olivier award winning play, Bull, is an allegory of Spanish bullfighting and a 45 minute white knuckle ride through the manipulative world of the modern workplace. Isobel, Thomas, and Tony are each scrambling to save their jobs with one destined for the sack from their daunting boss Carter. Surely his decision will be fair? Don’t be so sure. Two colleagues lie, cheat, taunt and victimise their way to success in order to make the other see red. This play is a stark and brutal look at bullying in the workplace which is guaranteed to hit you hard like a shot of tequila and make you squirm uncomfortably in your seat.

--- a/_shows/15_16/macbett.md
+++ b/_shows/15_16/macbett.md
@@ -110,7 +110,7 @@ assets:
   - type: poster
     image: macbett.jpg
 
-smugmug: KgHbCr
+prod_shots: KgHbCr
 ---
 
 If Monty Python and Terry Gilliam did Shakespeare, it'd be something like this. Arguably, a lot of Shakespeare’s work conveys a message of power being an inherently corrupting force - Macbeth being a prime example. Ionesco (one of the most prominent avant-garde writers within ‘The Theatre of the Absurd’) wrote Macbett as a fond parody of Macbeth. Ionesco is not mocking Shakespeare, he is satirising war and government in this profoundly funny and profane depiction of human nature.

--- a/_shows/15_16/master_and_margarita.md
+++ b/_shows/15_16/master_and_margarita.md
@@ -86,7 +86,7 @@ crew:
 - role: Technical Operator
   name: Arthur Mckechnie
 
-smugmug: 92R66x
+prod_shots: 92R66x
 
 assets:
   - type: poster

--- a/_shows/15_16/pornography.md
+++ b/_shows/15_16/pornography.md
@@ -86,7 +86,7 @@ crew:
   - role: Photography
     name: Natalia Gonzalez
 
-smugmug: rChMFv
+prod_shots: rChMFv
 
 assets:
   - type: poster

--- a/_shows/15_16/sex_cells.md
+++ b/_shows/15_16/sex_cells.md
@@ -84,7 +84,7 @@ assets:
   - type: poster
     image: sex_cells_poster.png
 
-smugmug: ZB3PM9
+prod_shots: ZB3PM9
 ---
 
 In a busy call centre, the four employees of Aphrodite, a sex toy manufacturer, take telephone orders for Teasey Maids, Titivators, and rotating pearl g-strings. However, beneath the cheerful customer service and easy banter, these very different women nurse their own desires and disappointments. Join Lily, Sylvie, Janice, Tiffany, and the hapless Mr Causeway in this wickedly funny and poignant new play about motherhood, relationships, anger, acceptance, motherhood, compassion, love, motherhood, belonging, motherhood, sex, cake and motherhood.

--- a/_shows/15_16/sketchy_characters.md
+++ b/_shows/15_16/sketchy_characters.md
@@ -45,7 +45,7 @@ assets:
   - type: poster
     image: sketchy_characters.jpg
 
-smugmug: PLjpNs
+prod_shots: PLjpNs
 ---
 
 “Sketchy Characters” is a sketch show featuring a range of performances. From puns to heresy, ancient Rome to Iron Man, “Sketchy Characters” satirises, demonises, and synthesises ideas and people from across the last 5000 years of human mediocrity.

--- a/_shows/15_16/the_ diary_of_anne_frank.md
+++ b/_shows/15_16/the_ diary_of_anne_frank.md
@@ -66,7 +66,7 @@ assets:
   - type: poster
     image: anne_frank_poster.jpg
 
-smugmug: pfVdD3
+prod_shots: pfVdD3
 ---
 
 Anne Frank’s is a story that everyone knows. Amidst a backdrop of brutality and devastation, a young girl gives us an insight into the experiences of the persecuted who were battling to maintain their sense of humanity during World

--- a/_shows/15_16/the_great_gatsby.md
+++ b/_shows/15_16/the_great_gatsby.md
@@ -56,7 +56,7 @@ crew:
 - role: Poster Designer
   name: Aneesa Kaleem
 
-smugmug: RMrTB5
+prod_shots: RMrTB5
 
 assets:
   - type: poster

--- a/_shows/15_16/west.md
+++ b/_shows/15_16/west.md
@@ -61,14 +61,14 @@ crew:
 
 tour:
 - venue: NSDF 2016
-- date_start: 
+- date_start:
 - date_end:
 
 assets:
   - type: poster
     image: west_poster.jpg
 
-smugmug: 3nCHmK
+prod_shots: 3nCHmK
 ---
 
 West by Steven Berkoff, first published in 1983, is a parable that follows Mike, leader of the N16 Gang, as he gears up to take on his most fearsome enemy, The

--- a/_shows/78_79/afternoon_tease.md
+++ b/_shows/78_79/afternoon_tease.md
@@ -5,10 +5,10 @@ period: Edinburgh
 season_sort: 420
 venue: unknown
 
-cast: 
+cast:
 - name: Matthew Bannister
 
-smugmug: GbTtM9
+prod_shots: GbTtM9
 ---
 
 

--- a/_shows/78_79/the_wit_to_woo.md
+++ b/_shows/78_79/the_wit_to_woo.md
@@ -9,6 +9,6 @@ playwright: Mervyn Peake
 cast:
   - name: Scott Cherry
 
-smugmug: dxHWH3
+prod_shots: dxHWH3
 ---
 

--- a/docs/shows.md
+++ b/docs/shows.md
@@ -27,7 +27,7 @@ The show records are stored as `_shows/YY_YY/show_name.md` with YY_YY being the 
 | `tour`<br>Not yet implemented<br />*(optional)* | List of *tours* the show has been on (NSDF *e.t.c.*). | Specify `venue`, `date_start`, `date_end` and `notes`. See [#12](https://github.com/newtheatre/history-project/issues/12). Shows taken to Edinbugh should have a separate show created under the `Edinburgh` period. |
 | `cast` | Cast members | Uses the [person list](/docs/person_list) format. |
 | `crew` | Crew members | Uses the [person list](/docs/person_list) format. |
-| `smugmug`<br />*(optional)* | SmugMug album ID for production shots | Use [util/smug-albums](/util/smug-albums/) to find the AlbumID. |
+| `prod_shots`<br />*(optional)* | SmugMug album ID for production shots | Use [util/smug-albums](/util/smug-albums/) to find the AlbumID. |
 | `photos`<br />*(optional)* | Production shots **(depreciated)** | Uses the [photos and assets](/docs/photos_and_assets) format. |
 | `assets`<br />*(optional)* | Publicity and other materials | Uses the [photos and assets](/docs/photos_and_assets) format. |
 | `published`<br>Not yet implemented<br />*(optional)* | *Not yet used!* | Will in the future hide the show if set to false. |
@@ -62,7 +62,7 @@ crew:
   - role: Producer
     name: Nick Stevenson
 
-smugmug: abcd123
+prod_shots: abcd123
 
 assets:
   - type: poster


### PR DESCRIPTION
Change `smugmug` to `prod_shots` to differentiate between new content (assets etc) to be hosted on smugmug.