### PR TITLE
Add headshot usage, re. #518

### DIFF
--- a/_coffee/smugmug_api.coffee
+++ b/_coffee/smugmug_api.coffee
@@ -51,6 +51,12 @@ $(document).ready ->
       window.d = data
       fill_image_list(data["Response"]["AlbumImage"])
 
-      fetch_usage_list "/feeds/smug_images.json", (data) ->
-        add_usage_data(data)
+      # Show assets
+      if key == "C87GJX"
+        fetch_usage_list "/feeds/smug_images.json", (data) ->
+          add_usage_data(data)
+      # Headshots
+      if key == "hZh8Jt"
+        fetch_usage_list "/feeds/smug_headshots.json", (data) ->
+          add_usage_data(data)
 

--- a/feeds/people.json
+++ b/feeds/people.json
@@ -1,5 +1,6 @@
 ---
-layout: null
+# People feed, used by several frontend scripts inc. person collect form to
+# populate fields with person data (name, grad year, shows/commitees).
 ---
 {% assign first = true %}
 {

--- a/feeds/search.json
+++ b/feeds/search.json
@@ -1,5 +1,6 @@
 ---
-layout: null
+# Search index feed, is processed by _coffee/search_index_generator.coffee to
+# build the actual index used on the live site.
 ---
 {% assign first = true %}
 [

--- a/feeds/smug_albums.json
+++ b/feeds/smug_albums.json
@@ -1,4 +1,5 @@
 ---
+# Lists all SM albums in use for prod shots, used to test usage of albums
 ---
 {
   {% assign first_actual = true %}

--- a/feeds/smug_headshots.json
+++ b/feeds/smug_headshots.json
@@ -1,0 +1,19 @@
+---
+# Lists all headshots by their SM ImageKey's, used to test usage of images
+# within headshot SM album.
+---
+{
+  {% assign first_actual = true %}
+
+{% for person in site.people %}
+{% if person.headshot %}
+{% unless first_actual %},{% endunless %}
+  {% assign first_actual = false %}
+  {{ person.headshot.key | jsonify }}: {
+    "title": {{ person.title | jsonify }},
+    "link": {{ person.url | jsonify }}
+  }
+{% endif %}
+{% endfor %}
+
+}

--- a/feeds/smug_images.json
+++ b/feeds/smug_images.json
@@ -1,4 +1,6 @@
 ---
+# Lists all show assets by their SM ImageKey's, used to test usage of images
+# within show asset SM album.
 ---
 {
   {% assign first_actual = true %}

--- a/util/smug-headshots.html
+++ b/util/smug-headshots.html
@@ -5,7 +5,7 @@ body_class: util-smug-album
 <p><em>The table may take several seconds to populate.</em></p>
 
 <table id="smug-images" data-album="hZh8Jt">
-<td><th>Thumbnail</th><th>Title</th><th>Filename</th><th>ImageKey</th></td>
+<td><th>Thumbnail</th><th>Title</th><th>Filename</th><th>ImageKey</th><th>Usage</th></td>
 
 </table>
 

--- a/util/smug-venues.html
+++ b/util/smug-venues.html
@@ -5,7 +5,7 @@ body_class: util-smug-album
 <p><em>The table may take several seconds to populate.</em></p>
 
 <table id="smug-images" data-album="BdFr84">
-<td><th>Thumbnail</th><th>Title</th><th>Filename</th><th>ImageKey</th></td>
+<td><th>Thumbnail</th><th>Title</th><th>Filename</th><th>ImageKey</th><th>Usage</th></td>
 
 </table>
 


### PR DESCRIPTION
Add usage col to https://history.newtheatre.org.uk/util/smug-headshots/ re #518 

![image](https://cloud.githubusercontent.com/assets/1690934/14764011/21e97228-09a0-11e6-8822-731b69a7cf19.png)

Lays groundwork for similar column for venue images when venue collection is a thing. #420 