### PR TITLE
Refactor link list processing as model, implement link register

### DIFF
--- a/_data/defs/link-list.yaml
+++ b/_data/defs/link-list.yaml
@@ -14,6 +14,11 @@
   short: Archive snapshot reference
   description: "The five-character [archive.is](https://archive.is) snapshot reference. References are case-sensitive."
 
+- attr: href_snapshot
+  type: string
+  short: URL to archive snapshot
+  generated: true
+
 - attr: username
   type: string
   short: Username on a service.
@@ -23,6 +28,11 @@
   type: string
   short: Title of resource 
   description: "Useful for headlines of news articles. Only include if suitable."
+
+- attr: icon
+  type: string
+  short: Icon class
+  description: Usually set by link type
 
 - attr: date
   type: date

--- a/_includes/link-list.html
+++ b/_includes/link-list.html
@@ -1,0 +1,17 @@
+<dl class="link-list">
+{% for link in include.list %}
+
+  <dt class="single-line">
+	<i class="fa fa-fw {{ link.icon }}"></i>
+	{% if link.href_snapshot %}
+	  <a href="{{ link.href_snapshot }}" {{ link.data }}>{{ link.title }}</a>
+	{% else %}
+	  <a href="{{ link.href }}" {{ link.data }}>{{ link.title }}</a>
+	{% endif %}
+	<span class="debug debug-hidden-content" data-debug-toggle>{{ link.comment }}</span>
+  </dt>
+  
+  <dd class="hidden">{{ link.href }}</dd>
+
+{% endfor %}
+</dl>

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -115,10 +115,11 @@ body_class: layout-person header-nobr content-nobr
         <dd>{{ career }}</dd>
       {% endfor %}
 
-      {% link_list links %}
-
-      {% link_list news %}
       </dl>
+
+      {% include link-list.html list=person.links %}
+
+      {% include link-list.html list=person.news %}
 
     </section>
 

--- a/_people/martha_wilson.md
+++ b/_people/martha_wilson.md
@@ -7,6 +7,7 @@ news:
     title: "Daring dozen: Old Vic talent list includes director who made secret Syria trip"
     date: 2015-11-26
     href: "http://www.standard.co.uk/goingout/theatre/daring-dozen-old-vic-talent-list-includes-director-who-made-secret-syria-trip-a3123711.html"
+    snapshot: Lpoqn
 ---
 
 

--- a/_plugins/hooks.rb
+++ b/_plugins/hooks.rb
@@ -2,6 +2,11 @@ Jekyll::Hooks.register :site, :pre_render do |site|
   Jekyll.logger.info "Rendering site..."
 end
 
+Jekyll::Hooks.register :site, :post_read do |site|
+  # Initialise the link register
+  site.data['link-register'] = LinkList::LinkRegister.new
+end
+
 Jekyll::Hooks.register :site, :post_write do |site|
   Jekyll.logger.info "Site written to disk"
 end

--- a/_plugins/link_list.rb
+++ b/_plugins/link_list.rb
@@ -2,9 +2,12 @@ SNAPSHOT_BASE = "https://archive.is"
 
 module LinkList
   class Link
-    def initialize(site, link_hash)
+    # Single link within a link list or link register
+
+    def initialize(site, link_hash, page_ref=nil)
       @link_hash = link_hash
       @site = site
+      @page_ref = page_ref
 
       # Select link type from data path or nil
       @link_type = @site.data['link-types'].select {
@@ -86,21 +89,48 @@ module LinkList
         'stars' => stars,
         'quote' => quote,
         'comment' => @link_hash['comment'],
+        'page' => @page_ref,
       }
     end
   end
 
   class LinkList
+    # List of links
+
     def initialize(site, linklist)
       @linklist = linklist
       @site = site
+      @page_ref = nil
+    end
+
+    def links(page_ref=nil)
+      @linklist.map do |link|
+        link = Link.new(@site, link, page_ref)
+        link
+      end
     end
 
     def to_liquid
-      @linklist.map do |link|
-        link = Link.new(@site, link)
-        link.to_liquid
+      links
+    end
+  end
+
+  class LinkRegister
+    # Register for holding all links to external resources for the site
+
+    def initialize
+      @link_register = Array.new
+    end
+
+    def add_list(list, page_ref)
+      # Create LinkList with page refs and push to register array
+      list.links(page_ref).each do |link|
+        @link_register << link
       end
+    end
+
+    def to_liquid
+      @link_register
     end
   end
 end

--- a/_plugins/link_list.rb
+++ b/_plugins/link_list.rb
@@ -1,74 +1,106 @@
-module Jekyll
-  class LinkListTag < Liquid::Tag
+SNAPSHOT_BASE = "https://archive.is"
 
-    def initialize(tag_name, markup, tokens)
-      super
-      @link_hash = markup.strip
-    end
-
-    def single_get_href(link)
-      # Used several times so spun out here
-      if not link.key?('href') then Jekyll.logger.abort_with(
-        "Link list:", "Missing href in #{@page['path']}") end
-      return link['href']
-    end
-
-    def single_link(link)
-      # Some sanity checks and useful exceptions
-      if not link.key?('type') then Jekyll.logger.abort_with(
-        "Link list:", "Missing type in #{@page['path']}") end
+module LinkList
+  class Link
+    def initialize(site, link_hash)
+      @link_hash = link_hash
+      @site = site
 
       # Select link type from data path or nil
-      link_type = @site.data['link-types'].select {
-        |i| i['type'] == link['type'] }[0]
-      link_type_default = @site.data['link-types'].select {
+      @link_type = @site.data['link-types'].select {
+        |i| i['type'] == link_hash['type'] }[0]
+      @link_type_default = @site.data['link-types'].select {
         |i| i['type'] == "default" }[0]
-
-      # Defaults
-      title = link['type']
-      icon = link_type_default['icon']
-      data = ""
-      if link.key?('comment') then comment = link['comment']
-      else comment = nil end
-
-      # If title, use
-      if link.key?('title') then title = link['title'] end
-
-      # Apply link type stuff
-      if link_type
-        if link_type.key?('icon') then icon = link_type['icon'] end
-        if link_type.key?('data') then data = link_type['data'] end
-        if link_type.key?('href')
-          if not link.key?('username') then Jekyll.logger.abort_with(
-            "Link list:", "Missing username in #{@page['path']}") end
-          href = link_type['href'].sub("???", link['username'])
-        else
-          href = single_get_href(link)
-        end
-      else
-        href = single_get_href(link)
-      end
-
-      """<dt class=\"single-line\">
-           <i class=\"fa fa-fw #{icon}\"></i>
-           <a href=\"#{href}\" #{data}>#{title}</a>
-           <span class=\"debug debug-hidden-content\" data-debug-toggle>#{comment}</span>
-         </dt>
-         <dd class=\"hidden\">#{href}</dd>\n"""
     end
 
-    def render(context)
-      @site = context.registers[:site]
-      @page = context.environments.first['page']
-
-      if @page.key?(@link_hash)
-        links = @page[@link_hash]
-        return links.collect { |link| single_link(link) }
+    def type
+      if @link_type['type']
+        @link_type['type']
       else
-        return nil
+        # TODO feed back into calling Jekyll plugin
+        raise 'Missing link type'
+      end
+    end
+
+    def href
+      if @link_type.key?('href')
+        @link_type['href'].sub("???", @link_hash['username'])
+      else
+        @link_hash['href']
+      end
+    end
+
+    def href_snapshot
+      if @link_hash.key?('snapshot')
+        "#{SNAPSHOT_BASE}/#{@link_hash['snapshot']}"
+      end
+    end
+
+    def snapshot
+      @link_hash['snapshot']
+    end
+
+    def username
+      @link_hash['username']
+    end
+
+    def title
+      if @link_hash.key?('title')
+        @link_hash['title']
+      else
+        @link_hash['type']
+      end
+    end
+    
+    def icon
+      @link_hash['icon'] || @link_type['icon'] || @link_type_default['icon']
+    end
+
+    def data
+      @link_hash['data'] || @link_type['data'] || @link_type_default['data']
+    end
+
+    def date
+      @link_hash['date']
+    end
+
+    def stars
+      @link_hash['stars']
+    end
+
+    def quote
+      @link_hash['quote']
+    end
+
+    def to_liquid
+      {
+        'type' => type,
+        'href' => href,
+        'href_snapshot' => href_snapshot,
+        'snapshot' => snapshot,
+        'username' => username,
+        'title' => title,
+        'icon' => icon,
+        'data' => data,
+        'date' => date,
+        'stars' => stars,
+        'quote' => quote,
+        'comment' => @link_hash['comment'],
+      }
+    end
+  end
+
+  class LinkList
+    def initialize(site, linklist)
+      @linklist = linklist
+      @site = site
+    end
+
+    def to_liquid
+      @linklist.map do |link|
+        link = Link.new(@site, link)
+        link.to_liquid
       end
     end
   end
 end
-
-Liquid::Template.register_tag('link_list', Jekyll::LinkListTag)

--- a/_plugins/people.rb
+++ b/_plugins/people.rb
@@ -122,6 +122,10 @@ module Jekyll
       person.data["path_name"] = make_hp_path(person.data["title"])
       person.data["decade"] = "#{person.data["graduated"]}"[0,3]
 
+      # Person link lists
+      person.data["links"] = LinkList::LinkList.new(@site, person.data["links"])
+      person.data["news"] = LinkList::LinkList.new(@site, person.data["news"])
+
       # People by filename
       @people_by_filename[person.basename_without_ext] = person
     end

--- a/_plugins/people.rb
+++ b/_plugins/people.rb
@@ -124,7 +124,9 @@ module Jekyll
 
       # Person link lists
       person.data["links"] = LinkList::LinkList.new(@site, person.data["links"])
+      @site.data['link-register'].add_list(person.data["links"], person)
       person.data["news"] = LinkList::LinkList.new(@site, person.data["news"])
+      @site.data['link-register'].add_list(person.data["news"], person)
 
       # People by filename
       @people_by_filename[person.basename_without_ext] = person

--- a/util/link-register.html
+++ b/util/link-register.html
@@ -1,0 +1,49 @@
+---
+---
+
+<h1>Link Register</h1>
+
+<table id="link-register" class="tablesorter">
+
+    <thead>
+        <tr>
+            <th>page</th>
+            <th>type</th>
+            <th>title</th>
+            <th>date</th>
+            <th>stars</th>
+            <th>quote</th>
+            <th>href</th>
+            <th>snapshot</th>
+            <th>comment</th>
+        </tr>
+    </thead>
+
+    <tbody>
+
+    {% for link in site.data.link-register %}
+        <tr>
+            <td><a href="{{ link.page.url }}">{{ link.page.title }}</a></td>
+            <td>{{ link.type }}</td>
+            <td>{{ link.title }}</td>
+            <td>{{ link.date }}</td>
+            <td>{{ link.stars }}</td>
+            <td>{{ link.quote }}</td>
+            <td><a href="{{ link.href }}" data-proofer-ignore>{{ link.href }}</a></td>
+            <td><a href="{{ link.href_snapshot }}" data-proofer-ignore>{{ link.snapshot }}</a></td>
+            <td>{{ link.comment }}</td>
+        </tr>
+    {% endfor %}
+
+    </tbody>
+
+</table>
+
+<script src="/js/lib.js"></script>
+<script src="/lib/tablesorter/dist/js/jquery.tablesorter.js"></script>
+
+<link rel="stylesheet" type="text/css" href="/lib/tablesorter/dist/css/theme.default.min.css" />
+
+<script type="text/javascript">
+    $("#link-register").tablesorter()
+</script>


### PR DESCRIPTION
- Link lists get replaced by model object on generation
- Link lists uses include template instead of Ruby interpolated string
- Links in those lists get added to the link register for display on util pages to help track links with snapshots
- Links with snapshots use snapshot links, in future probably want to present actual link as well, can't work out a nice way to do so currently