### PR TITLE
Change 'Report this page' to 'Message the editors'

### DIFF
--- a/_content/about/contributing.md
+++ b/_content/about/contributing.md
@@ -21,7 +21,7 @@ Don't worry if you aren't quite ready to part with your cherished New Theatre re
 
 We use an issue tracker to maintain a list of jobs to do. If you spot a misspelled name, a terrible typo or can help us fill in some blanks you can add to this by reporting problems with pages.
 
-Click the <strong class="tag"><i class="octicon octicon-issue-opened"></i> Report This Page</strong> button on the right when on the page you want to tell us about and complete a report.
+Click the <strong class="tag"><i class="ion-chatbox-working"></i> Message the Editors</strong> button on the right when on the page you want to tell us about and complete a report.
 
 Please keep in mind all reports are public. You can see [all reports made using this tool here](https://github.com/newtheatre/history-project/issues?q=label%3Areport-tool+).
 

--- a/_content/about/upload.md
+++ b/_content/about/upload.md
@@ -25,7 +25,7 @@ For inclusion on your alumni biography. Please ensure your upload has a filename
   <a href="https://newtheatre.smugmug.com/upload/7zcZFT/incoming" target="_blank" class="button-upload button">Upload photographs <i class="ion-ios-arrow-right"></i></a>
 </div>
 
-Please let us know you're going to upload by sending a message using the <strong class="tag"><i class="octicon octicon-issue-opened"></i> Report This Page</strong> on the page the images pertain to. Files should have sensible filenames so we know which show they go with.
+Please let us know you're going to upload by sending a message using the <strong class="tag"><i class="ion-chatbox-working"></i> Message the Editors</strong> button on the page the images pertain to. Files should have sensible filenames so we know which show they go with.
 
 ## Having trouble?
 

--- a/_includes/report.html
+++ b/_includes/report.html
@@ -3,7 +3,7 @@
 {% capture page_path %}{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}{% endcapture %}
 <div id="report-this-page" class="side-tab report-tab">
   <a href="https://github.com/newtheatre/history-project/issues/new?body={{page.url}}" data-proofer-ignore>
-    <i class="octicon octicon-issue-opened"></i><p class="report-tab-text">Report This Page</p>
+    <i class="ion-chatbox-working"></i><p class="report-tab-text">Message the Editors</p>
   </a>
 </div>
 {% unless page.editable == false %}
@@ -29,10 +29,10 @@
   <div data-report-close class="report-bg"></div>
   <div id="report-modal" class="report-modal">
     <div data-report-close class="report-close"><i class="octicon octicon-x"></i></div>
-    <h3><i class="octicon octicon-issue-opened"></i> Report a problem with this page</h3>
+    <h3><i class="ion-chatbox-working"></i> Message the editors about this page</h3>
     <div id="report-modal-content">
       <p>You can use the form below to post to our public <a href="https://github.com/newtheatre/history-project/issues">
-        issue tracker</a> about the page you're currently on - <strong>{{ page.title | escape_once }}</strong>. Let us know about
+        issue tracker</a> about the page you're currently on &ndash; <strong>{{ page.title | escape_once }}</strong>. Let us know about
         missing or incorrect details, typos or any other way this page could be improved.</p>
       <div class="report-form">
         <form id="report-issue-form" action="{{ site.ntbot_endpoint }}" method="POST">
@@ -54,16 +54,22 @@
     <div data-improve-close class="improve-close"><i class="octicon octicon-x"></i></div>
     <h3><i class="octicon octicon-pencil"></i> Improve this page</h3>
     <div id="improve-modal-content">
-      <p>Anyone can propose improvements to this page, while quite easy this is a multi-step process and you'll also need a free <a href="https://github.com/join">GitHub account</a>. Alternatively you can file a report for this page and have an editor do the work for you.</p>
+      <p>Anyone can propose improvements to this page, while quite easy this is a multi-step process and you'll also need a free <a href="https://github.com/join">GitHub account</a>. Alternatively you can file a report and have an editor do the work for you.</p>
 
 
       <div class="improve-actions">
         <div class="improve-action">
-          <a href="{{ edit_link }}" class="button button-improve" data-proofer-ignore>Propose improvements</a>
+          <a href="{{ edit_link }}" class="button button-improve" data-proofer-ignore>
+            <i class="octicon octicon-git-pull-request fa-fw"></i>
+            Propose improvements
+          </a>
           <p>Slower, but helps us more.</p>
         </div>
         <div class="improve-action">
-          <a data-report-this-page class="button button-report" href="https://github.com/newtheatre/history-project/issues/new?body={{page.url}}" data-proofer-ignore>File a report instead</a>
+          <a data-report-this-page class="button button-report" href="https://github.com/newtheatre/history-project/issues/new?body={{page.url}}" data-proofer-ignore>
+            <i class="ion-chatbox-working"></i>
+            Message editors instead
+          </a>
           <p>Quicker, less technically demanding.</p>
         </div>
       </div>

--- a/_sass/_report.sass
+++ b/_sass/_report.sass
@@ -33,6 +33,14 @@ $report-color-step: -60%
     font-size: $base-font-size * 2
     padding-right: $baseline
 
+  .ion-chatbox-working
+    position: relative
+    top: -2px
+  
+  .octicon-history
+    position: relative
+    top: 1px
+
   p
     font-size: $base-font-size
     font-weight: $font-weight-bold


### PR DESCRIPTION
I wonder if the text *"Report this page"* isn't very friendly. It suggests the user is pointing out fault rather than helpfully telling us about missing information. I suggest *"Message the Editors"*:

![image](https://cloud.githubusercontent.com/assets/1690934/18818518/3542163e-8373-11e6-8a82-6b034259b65a.png)

to

![image](https://cloud.githubusercontent.com/assets/1690934/18818525/3e839f2e-8373-11e6-9755-60afd3ce901f.png)

Thoughts?
