### PR TITLE
Download and run htmltest alongside htmlproofer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ _smugmug_cache/
 lib/
 node_modules/
 tmp/
+.htmltest/*
+_bin/htmltest
 
 for_shows_uncompressed
 for_shows_process

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,10 @@
+DirectoryPath: _site
+IgnoreDirectoryMissingTrailingSlash: true
+IgnoreURLs:
+- "history.newtheatre.org.uk"
+- "photos.smugmug.com"
+- "photos.newtheatre.org.uk"
+- "archive.is"
+IgnoreDirs:
+- "lib"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,21 @@ cache:
   - _smugmug_cache/
   - tmp/
   - ".sass-cache"
+  - .htmltest/
 before_install:
 - nvm install 4.2.6
 install:
 - bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}
 - npm install
 - bower install
+- curl http://fs.wjdp.uk/f/htmltest-nthp > _bin/htmltest
+- chmod +x _bin/htmltest
 before_script:
 - _bin/prep.sh
 script:
 - gulp build
+- _bin/htmltest --version
+- _bin/htmltest
 - gulp test
 after_success:
 - _bin/deploy.sh


### PR DESCRIPTION
I made a thing (htmltest), a semi-bleeding edge version of it has been added to the build pipeline of this project for alpha/beta/gamma testing. Can be removed easily if causing major problems.

This PR adds the following:
- commands to download a version of htmltest during install
- running htmltest before htmlproofer
- cache .htmlproofer cache directory
- a config file for htmlproofer