### PR TITLE
Limit smugmug album image fetch count to 350.

### DIFF
--- a/_data/defs/show.yaml
+++ b/_data/defs/show.yaml
@@ -172,7 +172,7 @@
 - attr: prod_shots
   type: string
   short: SmugMug album ID for production shots
-  description: "Use [util/smug-albums](/util/smug-albums/) to find the AlbumID."
+  description: "Use [util/smug-albums](/util/smug-albums/) to find the AlbumID. Fetch is limited to the first 350 items."
 
 - attr: smugmug_album
   type: hash

--- a/_plugins/smugmug_album.rb
+++ b/_plugins/smugmug_album.rb
@@ -24,13 +24,13 @@ class SmugAlbum < Smug
   def fetch_album_images(albumID)
     # Given an album id, return the SM objects in that album
     Jekyll.logger.info "Fetching SM Image List:", "#{ albumID }"
-    url = api_url("album/#{ albumID }!images", "count=9999")
+    url = api_url("album/#{ albumID }!images", "count=350")
     data = self.class.get(url)
     if data.key? "Response" and data["Response"].key? "AlbumImage"
       return data["Response"]["AlbumImage"]
     else
       Jekyll.logger.error "SM error:", "Invalid album images response"
-      puts url
+      puts data
       return false
     end
   end

--- a/_plugins/smugmug_album.rb
+++ b/_plugins/smugmug_album.rb
@@ -26,7 +26,7 @@ class SmugAlbum < Smug
     Jekyll.logger.info "Fetching SM Image List:", "#{ albumID }"
     url = api_url("album/#{ albumID }!images", "count=350")
     data = self.class.get(url)
-    if data.key? "Response" and data["Response"].key? "AlbumImage"
+    if data.code == 200 and data.key? "Response" and data["Response"].key? "AlbumImage"
       return data["Response"]["AlbumImage"]
     else
       Jekyll.logger.error "SM error:", "Invalid album images response"
@@ -42,7 +42,7 @@ class SmugAlbum < Smug
     imageIDs_as_parameter = imageIDs.join(',')
     url = api_url("image/#{ imageIDs_as_parameter }!#{ size }", sizeParameters)
     data = self.class.get(url)
-    if data.code == 200
+    if data.code == 200 and data.key? "Response" and data["Response"].key? sizeClass
       return data["Response"][sizeClass]
     else
       puts data


### PR DESCRIPTION
Rough average of the top 10 albums on the site currently. Prevents #692 from occurring while allowing large albums on SM.

Even though this exists we shouldn't dump everything on SM. 350 is still a very large number of photos.

Without a purge of the SM cache on Travis this change will take effect gradually.