### PR TITLE
Vagrant fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ To get the site running locally you will need a working Ruby environment, the bu
 - OR `gulp debug` does the same but skips minification and enables Jekyll's incremental builds.
 - `gulp server` to serve the site using the built in webserver. Changes to Sass & Coffee files will trigger an automatic frontend rebuild and reload. Content (Jekyll) changes will not, this is because Jekyll takes a considerable time to run.
 
+To get more verbose output from Jekyll, run `export JEKYLL_LOG_LEVEL=debug` before building.
+
 ### Test
 
 - `gulp test` to run test suite locally. Currently we test for bad links, valid image tags, script references and the validity of site JSON feeds.
@@ -54,6 +56,8 @@ Once you have download the requirements and installed them successfully you simp
 - `vagrant up`
 - `vagrant ssh`
 - `cd /vagrant`
+- `gulp build`
+- `gulp server`
 
 The vagrant box has port 8000 mapped to 8000 on your local machine, so `http://127.0.0.1:8000` should still work.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,10 +44,14 @@ chmod +x _bin/htmltest
 
 SCRIPT
 
-Vagrant::Config.run do |config|
-
+Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
-  config.vm.forward_port 8000, 8000
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+  end
+  
+  config.vm.network "forwarded_port", guest:8000, host:8000
   config.vm.provision :shell, inline: $provision
 
   config.ssh.forward_agent = true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,6 +38,10 @@ cd /vagrant
 bundle install
 npm install
 bower install --allow-root
+
+curl https://f000.backblazeb2.com/file/wjdp-lib/htmltest > _bin/htmltest
+chmod +x _bin/htmltest
+
 SCRIPT
 
 Vagrant::Config.run do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,11 @@
 $provision = <<SCRIPT
 sudo apt-add-repository ppa:brightbox/ruby-ng
+
+# https://github.com/nodesource/distributions
+curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+
 sudo apt-get update && sudo apt-get -y install build-essential git
-sudo apt-get -y install nodejs npm imagemagick ruby2.2 ruby2.2-dev
+sudo apt-get -y install nodejs imagemagick ruby2.2 ruby2.2-dev
 
 # Generate locales, fixes bug where Vagrant VM breaks on some UTF-8
 sudo locale-gen en_GB en_GB.UTF-8
@@ -28,7 +32,7 @@ update-alternatives --display ruby
 
 sudo gem install bundler
 sudo ln -s /usr/bin/nodejs /usr/bin/node
-sudo npm install -g coffee-script bower
+sudo npm install -g gulp coffee-script bower
 
 cd /vagrant
 bundle install


### PR DESCRIPTION
Have updated the Vagrantfile with recent changes to dependencies, and increased the default VM memory to 1024mb, since the build requires more than 512mb. 

Added information to README to make it clear you still need to run `gulp` stuff after running `vagrant up`