### PR TITLE
Retire legacy path redirection from October 2015

### DIFF
--- a/_plugins/committee.rb
+++ b/_plugins/committee.rb
@@ -13,7 +13,8 @@ module Jekyll
     end
 
     def get_committee_legacy_paths(committee)
-      "committees/#{committee.basename_without_ext}.html"
+      # Retired, was live 2015-10-28 until 2017-02-24
+      # "committees/#{committee.basename_without_ext}.html"
     end
 
     def generate_committee(committee)
@@ -28,7 +29,8 @@ module Jekyll
       end
 
       # Generate the legacy path for 301 redirect re. #142 Make semantic and pretty urls
-      committee.data["redirect_from"] = get_committee_legacy_paths(committee)
+      # No legacy paths currently, disable
+      # committee.data["redirect_from"] = get_committee_legacy_paths(committee)
     end
 
     def generate(site)

--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -112,7 +112,8 @@ module Jekyll
     end
 
     def get_show_legacy_paths(show)
-      "shows/#{show.data['year']}/#{show.basename_without_ext}.html"
+      # Retired, was live 2015-10-29 until 2017-02-24
+      # "shows/#{show.data['year']}/#{show.basename_without_ext}.html"
     end
 
     IGNORE_MISSING_IN_SEASONS = [
@@ -179,7 +180,8 @@ module Jekyll
       show.data["smugmug_album"] = get_show_smugmug(show)
 
       # Generate the legacy path for 301 redirect re. #142 Make semantic and pretty urls
-      show.data["redirect_from"] = Array(get_show_legacy_paths(show)).freeze
+      # No legacy paths currently, disable
+      # show.data["redirect_from"] = Array(get_show_legacy_paths(show)).freeze
 
       # Replace assets' image attr with a SmugImage
       show.data["assets"] ||= []

--- a/_plugins/year.rb
+++ b/_plugins/year.rb
@@ -74,7 +74,8 @@ module Jekyll
     end
 
     def get_year_legacy_path(year)
-      "years/#{year.basename_without_ext}.html"
+      # Retired, was live 2015-10-29 until 2017-02-24
+      # "years/#{year.basename_without_ext}.html"
     end
 
     def get_year_slug(year)
@@ -98,7 +99,8 @@ module Jekyll
       @top_show_count ||= 0 # Instance var common to all years
       @top_show_count = year.data["show_count"] if year.data["show_count"] > @top_show_count
 
-      year.data["redirect_from"] = Array(get_year_legacy_path(year)).freeze
+      # No legacy paths currently, disable
+      # year.data["redirect_from"] = Array(get_year_legacy_path(year)).freeze
     end
 
     def generate(site)


### PR DESCRIPTION
Normally would be very against removing redirection for old URLs, you should keep them forever.

However, in this case I'm seeing ~80s reduction in build time. And that's far more valuable tbh.