### PR TITLE
Humans/People from datafile, update people

### DIFF
--- a/_content/about/about.md
+++ b/_content/about/about.md
@@ -24,10 +24,9 @@ See the [contributing](/contributing/) section for details on how to help out.
 
 ## People
 
-- **Project Lead:** Phil Geller
-- **Development Lead:** Will Pimblett
-- **Editor:** Nathan Penney
-- **Editor:** Nick Stevenson
+{% for person in site.data.humans %}
+- **{{ person.role }}:** [{{ person.name }}](/people/{{ person.bio }})
+{% endfor %}
 
 </div>
 <div class="grid-8" markdown="1">
@@ -53,7 +52,7 @@ See the [contributing](/contributing/) section for details on how to help out.
 
 ## Open codebase
 
-The entire codebase used to build this website is available on [GitHub](https://github.com/newtheatre/history-project). While the project as a whole isn't particularly helpful for other organizations, what we're doing here can be described as [*coding in the open*](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/), rather than building an open source project. That said parts of the project may be of interest or use to others. This repository is a mix of source and content, as such there are two licences that apply.
+The entire codebase used to build this website is available on [GitHub](https://github.com/newtheatre/history-project). While the project as a whole isn't particularly helpful for other organizations, rather than building an open source project what we're doing can be described as [*coding in the open*](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/). That said parts of the project may be of interest or use to others. This repository is a mix of source and content, as such there are two licences that apply.
 
 - All source files (HTML templates, Sass, CoffeeScript, Ruby, shell scripts) are released under the [MIT licence](https://opensource.org/licenses/MIT).
-- All content files (HTML files, Markdown, YAML datafiles, images, graphics) are copyright © The Nottingham New Theatre 2016.
+- All content files (HTML files, Markdown, YAML datafiles, images, graphics) are Copyright © The Nottingham New Theatre {{ site.time | date: "%Y" }}.

--- a/_content/humans.txt
+++ b/_content/humans.txt
@@ -1,34 +1,21 @@
 ---
 permalink: /humans.txt
+excerpt: ""
 ---
 /* TEAM */
-  Project Lead / Developer: Will Pimblett
-  Bio: https://history.newtheatre.org.uk/people/will_pimblett/
-  Contact: webmaster [at] newtheatre.org.uk
-  Twitter: @willpimblett
-  From: Cambridge, UK
+  {% for person in site.data.humans %}{{ person.role }}: {{ person.name }}
+  Bio: {{ site.url }}/people/{{ person.bio }}/
 
-  Project Lead / Content: Phil Geller
-  Bio: https://history.newtheatre.org.uk/people/philip_geller/
-  Twitter: @PJGeller
-
-  Editor: Nick Stevenson
-  Bio: https://history.newtheatre.org.uk/people/nick_stevenson/
-  Twitter: @njstevenson14
-
-  Editor: Nathan Penney
-  Bio: https://history.newtheatre.org.uk/people/nathan_penney/
-  Twitter: @nhyty96
-
+  {% endfor %}
 /* THANKS */
-
   Vagrant Setup: Tom Price
 
   Browser testing tools generously provided by BrowserStack.
 
 /* SITE */
-  Last update: {{site.time | date: "%Y-%m-%d" }}
+  Last update: {{ site.time | date: "%Y-%m-%d" }}
   Language: English
   Doctype: HTML5
-  Build: Jekyll, Travis CI
+  Build: Gulp, Jekyll, Travis CI
+  Test: htmltest, jsonlint
   IDE: Sublime Text

--- a/_data/humans.yaml
+++ b/_data/humans.yaml
@@ -1,0 +1,19 @@
+- name: Will Pimblett
+  role: Project Lead
+  bio: will_pimblett
+- name: Nathan Penney
+  role: Editor
+  bio: nathan_penney
+- name: Phil Geller
+  role: Editor
+  bio: philip_geller
+- name: Nick Stevenson
+  role: Editor
+  bio: nick_stevenson
+- name: Ben Woodford
+  role: Contributor
+  bio: ben_woodford
+- name: David Taylor
+  role: Contributor
+  bio: david_taylor
+

--- a/feeds/search.json
+++ b/feeds/search.json
@@ -1,6 +1,7 @@
 ---
 # Search index feed, is processed by _coffee/search_index_generator.coffee to
 # build the actual index used on the live site.
+excerpt: ""
 ---
 {% assign first = true %}
 [


### PR DESCRIPTION
Use data/humans.yaml to generate people section in about and humans.txt.

Bumped Geller down a peg :)

Rough idea for contributor: 20 odd commits / or understand my Ruby @davidtaylorhq :)

Added excerpt lines to humans.txt, re Jekyll bug https://github.com/jekyll/jekyll/issues/5596

Use site.time to write copyright line.