### PR TITLE
Added object-fit css to lightbox images, fixes #681

### DIFF
--- a/_sass/_lightbox.sass
+++ b/_sass/_lightbox.sass
@@ -32,6 +32,7 @@
 
 .lightbox-box__image
   height: 100%
+  object-fit: contain
 
 .lightbox-box__load
   position: fixed


### PR DESCRIPTION
See issue #681
Browser support is pretty good: http://caniuse.com/#feat=object-fit
IE/Edge users can deal with slightly stretchy things