### PR TITLE
Refactor person_list include (add icon switch)

### DIFF
--- a/_includes/person_list.html
+++ b/_includes/person_list.html
@@ -1,5 +1,5 @@
 {% capture unknowns %}
-{% for person in people %}
+{% for person in include.people %}
 {% if person.role == "unknown" %}
 X
 {% elsif person.name == "unknown" %}
@@ -13,7 +13,7 @@ X
 {% endif %}
 
 <ul class="person-list">
-{% for person in people %}
+{% for person in include.people %}
   <li class="person-single">
 
     {% if person.comment %}
@@ -50,7 +50,7 @@ X
       {% if person.role == "unknown" %}
         <span class="unknown">Unknown</span>
       {% else %}
-        {% if site.data.role-icons[person.role] %}
+        {% if site.data.role-icons[person.role] and include.enable_role_icons != false %}
         <i class="{{ site.data.role-icons[person.role] }}"></i>
         {% endif %}
 

--- a/_layouts/committee.html
+++ b/_layouts/committee.html
@@ -14,8 +14,7 @@ body_class: layout-committee
   	{% include boxes/committee_short.html %}
   {% endif %}
 
-  {% assign people = page.committee %}
-  {% include person_list.html %}
+  {% include person_list.html people=page.committee enable_role_icons=true %}
 </div>
 
 

--- a/_layouts/show.html
+++ b/_layouts/show.html
@@ -182,7 +182,7 @@ body_class: section-archives layout-show
      <div class="show-photos-controls__inner">
       <div class="fade-out-overlay"></div>
       <div class="gallery-control">
-        <a href="{{ show.smugmug_album.WebUri }}" 
+        <a href="{{ show.smugmug_album.WebUri }}"
            title="Show all photos"
            data-gallery-toggle>
           <div class="show-label" data-show-label>
@@ -233,23 +233,27 @@ body_class: section-archives layout-show
       <div class="debug-abs-top-left" data-debug-toggle title="Number of cast">{{ show.cast.size }}</div>
       {% unless show.ignore_missing and show.cast.size == null %}<h3>Cast</h3>{% endunless %}
       {% if show.cast == null %}
-      {% unless show.ignore_missing %}{% include boxes/show_cast_missing.html %}{% endunless %}
+        {% unless show.ignore_missing %}
+          {% include boxes/show_cast_missing.html %}
+        {% endunless %}
       {% else %}
-      {% assign people = show.cast %}
-      {% include person_list.html %}
+        {% include person_list.html people=show.cast enable_role_icons=false %}
       {% endif %}
     </section>
     <section class="show-crew debug-container">
       <div class="debug-abs-top-left" data-debug-toggle title="Nunber of crew">{{ show.crew.size }}</div>
       {% unless show.ignore_missing and show.crew.size == null %}<h3>Crew</h3>{% endunless %}
       {% if show.crew.size < site.show_low_crew %}
-      {% unless show.ignore_missing %}{% include boxes/show_crew_short.html %}{% endunless %}
+        {% unless show.ignore_missing %}
+          {% include boxes/show_crew_short.html %}
+        {% endunless %}
       {% endif %}
       {% if show.crew == null %}
-      {% unless show.ignore_missing %}{% include boxes/show_crew_missing.html %}{% endunless %}
+        {% unless show.ignore_missing %}
+          {% include boxes/show_crew_missing.html %}
+        {% endunless %}
       {% else %}
-      {% assign people = show.crew %}
-      {% include person_list.html %}
+        {% include person_list.html people=show.crew enable_role_icons=true %}
       {% endif %}
     </section>
   </div>

--- a/_layouts/year.html
+++ b/_layouts/year.html
@@ -41,8 +41,7 @@ current: archives
         {% include boxes/committee_short.html %}
       {% endif %}
 
-      {% assign people = page.committee.committee %}
-      {% include person_list.html %}
+      {% include person_list.html people=page.committee.committee enable_role_icons=true %}
 
     {% else %}
 


### PR DESCRIPTION
- Add an enable_role_icon switch, will fix #611
- Pass people in as an include arg rather than a global var.
- Change all refs to this include match refactor.
- Indent format fix of show.html cast/crew.

![image](https://cloud.githubusercontent.com/assets/1690934/23968313/213af12e-09ba-11e7-8a99-b2befc24df99.png)
_(No longer a camera here, cast not crew)_