### PR TITLE
Validate person filename against title key

### DIFF
--- a/_plugins/people.rb
+++ b/_plugins/people.rb
@@ -23,7 +23,7 @@ module Jekyll
 
     def make_path(title)
       # Downcase, remove specials, space->underscore
-      path_no_ext = title.downcase.gsub(/[^0-9a-z \-]/i, '').gsub(' ','_')
+      path_no_ext = make_hp_path(title)
       "/#{path_no_ext}"
     end
 
@@ -96,6 +96,17 @@ module Jekyll
 
     def generate_person(person)
       """Method called on all people"""
+      # Validate things
+      if not person.data.has_key?("title")
+        Jekyll.logger.abort_with("Person record #{person.basename_without_ext} missing key 'title'")
+      end
+
+      if make_hp_path(person.data["title"]) != person.basename_without_ext
+        # Ensure the page title matches the filename, as we generate links to the filename elsewhere given the title.
+        # See issue #649
+        Jekyll.logger.abort_with("Person record #{person.basename_without_ext} does not match 'title': '#{person.data['title']}'")
+      end
+
       # Names
       person.data["name"] = person.data["title"]
       person.data["forename"] = person.data["title"].split[0..-2].join(" ")


### PR DESCRIPTION
Elsewhere on the site we generate links to person records before the
objects exist given the person's name (title) using the make_hp_path
function. This validation errors the build if a person record's
filename != make_hp_path(title).

Also removed duplication of the make_hp_path functionality in
PlaceholderPeoplePage::make_path. Made it use the function.

Will resolve #649 

As a single (useful) commit this should be rebased onto master.