### PR TITLE
Refactor bourbon depreciations (sass)

### DIFF
--- a/_sass/_buttons.sass
+++ b/_sass/_buttons.sass
@@ -28,7 +28,7 @@
 
   // Hand pointer & no text highlighting
   cursor: pointer
-  @include user-select(none)
+  user-select: none
 
   position: relative
 

--- a/_sass/_debug.sass
+++ b/_sass/_debug.sass
@@ -43,7 +43,7 @@ $debug-data-term-width: 20%
       background: $color-debug-attr-required
     .debug-data__term--generated
       background: $color-debug-attr-generated
-    
+
     dd
       margin-left: $debug-data-term-width
       margin-bottom: 0
@@ -92,7 +92,7 @@ $debug-data-term-width: 20%
     .mob-land
       display: inline
       i:before
-        @include transform(rotate(90deg))
+        transform: rotate(90deg)
   @include respond-to(tab-port)
     .tab-port
       display: inline
@@ -100,7 +100,7 @@ $debug-data-term-width: 20%
     .tab-land
       display: inline
       i:before
-        @include transform(rotate(90deg))
+        transform: rotate(90deg)
   @include respond-to(med-desk)
     .med-desk
       display: inline

--- a/_sass/_header.sass
+++ b/_sass/_header.sass
@@ -243,7 +243,7 @@ $title-text-baseline: 1.2
 
   border: none
 
-  @include placeholder
+  &:placeholder
     color: rgba($color-text-black, 0.3)
 
   @include no-focus
@@ -258,7 +258,7 @@ $title-text-baseline: 1.2
 
     font-size: 0.9rem
 
-    @include placeholder
+    &:placeholder
       color: rgba($color-text-white, 0.25)
 
     // Re-enable as disable by default

--- a/_sass/_layout.sass
+++ b/_sass/_layout.sass
@@ -27,7 +27,7 @@ body
   top: 0
   width: 100%
   height: 220px
-  @include background-image(linear-gradient($color-background-alt 0, transparent 99%))
+  background-image: linear-gradient($color-background-alt 0, transparent 99%)
 
 .site-content
   min-height: 500px

--- a/_sass/_people-grid.sass
+++ b/_sass/_people-grid.sass
@@ -56,7 +56,7 @@
       @include no-focus
       &:focus
         .person-headshot-placeholder
-          // Tint background of silhouette 
+          // Tint background of silhouette
           background: $color-focus
 
         .name
@@ -133,7 +133,7 @@
     @include set-property-to-gutter(padding-right)
     display: flex
 
-    @include user-select(none)
+    user-select: none
 
     li
       flex-grow: 1

--- a/_sass/_person-list.sass
+++ b/_sass/_person-list.sass
@@ -45,7 +45,7 @@
     // Allow relative positioning
     position: relative
     // Smooth JS adjustments to top
-    @include transition(top 1s ease-out)
+    transition: top 1s ease-out
 
     width: 100%
     background: $color-nnt-purple

--- a/_sass/_playwrights.sass
+++ b/_sass/_playwrights.sass
@@ -19,7 +19,7 @@ $color-plays: lighten($color-playwright, 15%)
   position: relative
 
   select
-    @include appearance(none)
+    appearance: none
     font-size: 1em
     font-weight: $font-weight-bold
 

--- a/_sass/_report.sass
+++ b/_sass/_report.sass
@@ -37,7 +37,7 @@ $report-color-step: -60%
   .ion-chatbox-working
     position: relative
     top: -2px
-  
+
   .octicon-history
     position: relative
     top: 1px
@@ -48,7 +48,7 @@ $report-color-step: -60%
     min-width: 220px
 
 
-  @include transition(all ease-out 0.25s)
+  transition: all ease-out 0.25s
 
   &:hover, &:focus
     right: 0px

--- a/_sass/_shows.sass
+++ b/_sass/_shows.sass
@@ -80,7 +80,7 @@ $show-photos-mob-gutter: 7px
     padding-top: $baseline
 
   // Show-y hide-y
-  @include transition(max-height 0.3s ease-out)
+  transition: max-height 0.3s ease-out
 
   &.show-photos__inner--show
     // We now calculate a max-height on an ad-hoc basis


### PR DESCRIPTION
Switch out bourbon includes for generic CSS. Will be caught and prefixed by out post-processor (if within browser support range).

Will fix #758.

This should be ready to go once tests pass, rebase onto master.