### PR TITLE
Add support for video in show assets

### DIFF
--- a/_coffee/app/lightbox.coffee
+++ b/_coffee/app/lightbox.coffee
@@ -69,7 +69,9 @@ class Lightbox
       <div class="lightbox-box__load">
         <i class="ion-load-c"></i>
       </div>
-      <img class="lightbox-box__image" src="" alt="" />
+      <div class="lightbox-box__content">
+
+      </div>
     </div>
     """
     document.body.appendChild(@lb)
@@ -84,10 +86,11 @@ class Lightbox
 
     # Save ref to load spinner
     @loadSpinnerEl = @lb.querySelector('.lightbox-box__load')
-    @imageEl = @lb.querySelector('.lightbox-box__image')
 
-    # Add load complete event handler
-    @imageEl.addEventListener('load', @imageLoaded)
+    # Image or video goes in here
+    @contentEl = @lb.querySelector('.lightbox-box__content')
+    @imageEl = null
+    @videoEl = null
 
     # Remove L&R if single image
     if @lightboxGallery.galleryLinks.length == 1
@@ -108,16 +111,45 @@ class Lightbox
       # Loop around
       @changeImage(@lightboxGallery.galleryLinks.length - 1)
 
-  changeImage: (i) ->
-    @loadSpinnerEl.classList.add('lightbox-box__load--show')
-    @imageEl.classList.add('lightbox-box__image--load')
-    @imageEl.src = @lightboxGallery.galleryLinks[i].href
-    @i = i
+  setupImage: ->
+    # Create image element to use
+    @contentEl.innerHTML = "<img class=\"lightbox-box__image\" src=\"\" alt=\"\" />"
+    @videoEl = null
+    @imageEl = @contentEl.querySelector('.lightbox-box__image')
+    # Add load complete event handler
+    @imageEl.addEventListener('load', @imageLoaded)
 
   imageLoaded: (ev) =>
     # Image load has complete, hide spinner and fade in image
     @loadSpinnerEl.classList.remove('lightbox-box__load--show')
     @imageEl.classList.remove('lightbox-box__image--load')
+
+  setupVideo: (src) ->
+    # Create video element to use
+    @contentEl.innerHTML = """<video class="lightbox-box__video lightbox-box__video--load" controls autoplay>
+      <source src="#{src}" type="video/mp4" />
+    </video>"""
+    @imageEl = null
+    @videoEl = @contentEl.querySelector('.lightbox-box__video')
+    @videoEl.addEventListener('playing', @videoLoaded)
+
+  videoLoaded: (ev) =>
+    # Video load has complete, hide spinner and fade in image
+    @loadSpinnerEl.classList.remove('lightbox-box__load--show')
+    @videoEl.classList.remove('lightbox-box__video--load')
+    ev.target.removeEventListener(ev.type, arguments.callee)
+
+  changeImage: (i) ->
+    @loadSpinnerEl.classList.add('lightbox-box__load--show')
+    switch @lightboxGallery.galleryLinks[i].dataset.type
+      when "image"
+        if not @imageEl then @setupImage()
+        @imageEl.classList.add('lightbox-box__image--load')
+        @imageEl.src = @lightboxGallery.galleryLinks[i].href
+      when "video"
+        @setupVideo(@lightboxGallery.galleryLinks[i].href)
+      else console.error('Invalid lightbox gallery type')
+    @i = i
 
   close: =>
     # Unfreeze scrolling
@@ -132,7 +164,7 @@ class Lightbox
     # Remove ref for this lightbox from gallery
     @lightboxGallery.deleteLightbox()
     # Rebind page arrow keys, remove esc listener
-    bindArrows()
+    bindKeys()
     Mousetrap.unbind('esc')
     window.disable_keyboard_nav = false
 

--- a/_coffee/scripts/utility.coffee
+++ b/_coffee/scripts/utility.coffee
@@ -56,7 +56,7 @@ $(document).ready ->
       fill_image_list(data["Response"]["AlbumImage"])
 
       # Show assets
-      if key == "C87GJX"
+      if key == "C87GJX" or key == "j3PdMh"
         fetch_usage_list "/feeds/smug_images.json", (data) ->
           add_usage_data(data)
           $("#smug-images").tablesorter()

--- a/_content/docs/photos-and-assets.md
+++ b/_content/docs/photos-and-assets.md
@@ -10,15 +10,7 @@ Show records currently have a *'Publicity Materials'* and *'Production Shots'* s
 
 ## <i class="fa fa-tags"></i> Attribute Reference
 
-| Attribute | Job | Description |
-|:-|:-|:-|
-| `type` | Type of asset | The type of asset, the first of type *poster* will be used as the show's poster. List non-exhaustive, should be lowercase: *photo, poster, flyer, programme*. |
-| `image`<br />*(semi-optional)*| The SmugMug ID of the image | Find IDs using the [show asset utility](/util/smug-show-assets/). |
-| `filename`<br />*(semi-optional)* | If non-image (PDF etc) the filename | Will look under `assets/for_shows/`. |
-| `title`<br />*(optional)* | Asset title | Is shown when graphical representation of file is not possible, required for PDF files and similar. |
-| `caption`<br />*(image only, optional)* | Image caption | Is shown when image is clicked on to make big. |
-| `page`<br />*(optional)* | Orders within a type, should be a number | For type programme it is the page number where the front page is `1`, for a single page flyer the front would be `1` and the back `2`. Shouldn't be required for multipage files such as PDFs. |
-| `display_image`<br />*(optional)* | If `true` sets asset as display image | Overrides the order of precedence in selecting a show's display image. Ensure asset is an image. |
+{% include def-doc.html def=site.data.defs.assets %}
 
 ## <i class="octicon octicon-code"></i> Example
 

--- a/_data/defs/assets.yaml
+++ b/_data/defs/assets.yaml
@@ -1,0 +1,42 @@
+- attr: type
+  type: string
+  short: Type of asset
+  description: >
+    The type of asset, the first of type *poster* will be used as the show's
+    poster. List non-exhaustive, should be lowercase: *photo, poster, flyer,
+    programme*.
+  required: true
+
+- attr: image
+  type: string
+  short: SmugMug ID of the image
+  description: >
+    Find IDs using the [show asset utility](/util/smug-show-assets/)
+
+- attr: filename
+  type: string
+  short: If non-image (PDF etc) the filename
+  description: >
+    Will look under `assets/for_shows/`
+
+- attr: title
+  type: string
+  short: Asset title
+  description: >
+    Is shown when graphical representation of file is not possible, required
+    when using the `filename` key.
+
+- attr: page
+  type: number
+  short: Orders within a type
+  description: >
+    For type programme it is the page number where the front page is `1`, for a
+    single page flyer the front would be `1` and the back `2`. Not needed for
+    multipage files such as PDFs.
+
+- attr: display_image
+  type: boolean
+  short: Force an image asset to be used as the display_image
+  description: >
+    Overrides the order of precedence in selecting a show's display image.
+    Ensure asset is an image, not a file.

--- a/_data/defs/assets.yaml
+++ b/_data/defs/assets.yaml
@@ -13,6 +13,12 @@
   description: >
     Find IDs using the [show asset utility](/util/smug-show-assets/)
 
+- attr: video
+  type: string
+  short: SmugMug ID of the video
+  description: >
+    Find IDs using the [show video utility](/util/smug-show-video/)
+
 - attr: filename
   type: string
   short: If non-image (PDF etc) the filename

--- a/_data/defs/assets.yaml
+++ b/_data/defs/assets.yaml
@@ -17,7 +17,7 @@
   type: string
   short: SmugMug ID of the video
   description: >
-    Find IDs using the [show video utility](/util/smug-show-video/)
+    Find IDs using the [show video utility](/util/smug-show-videos/)
 
 - attr: filename
   type: string

--- a/_includes/show_assets_list.html
+++ b/_includes/show_assets_list.html
@@ -19,10 +19,19 @@
   {% elsif asset.image %}
 
     <li class="show-asset-image debug-container">
-      <a class="lightbox-link" rel="assets" href="{{ asset.image.xlarge }}" title="{{ asset.caption }}">
+      <a class="lightbox-link" rel="assets" href="{{ asset.image.xlarge }}" title="{{ asset.caption }}" data-type="image">
         <img src="{{ asset.image.small }}" alt="{{ asset.type }} {{ asset.caption }}" title="{{ asset.caption }}" />
       </a>
       <div class="debug-abs-bottom-left" data-debug-toggle title="ImageKey">{{ asset.image.key }}</div>
+    </li>
+
+  {% elsif asset.video %}
+
+    <li class="show-asset-image debug-container">
+      <a class="lightbox-link" rel="assets" href="{{ asset.video.video1920 }}" title="{{ asset.caption }}" data-type="video">
+        <img src="{{ asset.video.small }}" alt="{{ asset.type }} {{ asset.caption }}" title="{{ asset.caption }}" />
+      </a>
+      <div class="debug-abs-bottom-left" data-debug-toggle title="ImageKey">{{ asset.video.key }}</div>
     </li>
 
   {% endif %}

--- a/_layouts/show.html
+++ b/_layouts/show.html
@@ -159,7 +159,8 @@ body_class: section-archives layout-show
       <div class="show-photo-single debug-container">
         <a class="lightbox-link"
            href="{{ image.LargeImage.Url }}"
-           title="{{ image.Title | escape_once }}">
+           title="{{ image.Title | escape_once }}"
+           data-type="image">
           <img class="lazy-image"
                src="/images/image-preload.png"
                data-lazy-src="{{ image.ThumbImage.Url }}"

--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -188,6 +188,8 @@ module Jekyll
       show.data["assets"].each do |asset|
         if asset.key? "image"
           asset["image"] = SmugImage.new(asset["image"])
+        elsif asset.key? "video"
+          asset["video"] = SmugImage.new(asset["video"])
         end
       end
 

--- a/_plugins/smugmug_image.rb
+++ b/_plugins/smugmug_image.rb
@@ -20,6 +20,13 @@ class SmugImage < Smug
     'ImageSizeX2Large',
     'ImageSizeX3Large',
     'ImageSizeOriginal',
+    'VideoSize110',
+    'VideoSize200',
+    'VideoSize320',
+    'VideoSize640',
+    'VideoSize960',
+    'VideoSize1280',
+    'VideoSize1920',
   ]
 
   CUSTOM_SIZES = [
@@ -39,7 +46,7 @@ class SmugImage < Smug
     Struct::CustomSize.new("person_thumb_1", "41x41!"),
     Struct::CustomSize.new("person_thumb_2", "82x82!"),
     Struct::CustomSize.new("person_thumb_3", "123x123!"),
-    
+
     Struct::CustomSize.new("person_bio_s", "96x96!"),
     Struct::CustomSize.new("person_bio_m", "160x160!"),
     Struct::CustomSize.new("person_bio", "160x160!"),
@@ -111,8 +118,17 @@ class SmugImage < Smug
         "x2large" => getSize("ImageSizeX2Large"),
         "x3large" => getSize("ImageSizeX3Large"),
         "original" => getSize("ImageSizeOriginal"),
+
+        # SM named sizes for video are though
+        "video110" => getSize('VideoSize110'),
+        "video200" => getSize('VideoSize200'),
+        "video320" => getSize('VideoSize320'),   # 180
+        "video640" => getSize('VideoSize640'),   # 360
+        "video960" => getSize('VideoSize960'),   # 540
+        "video1280" => getSize('VideoSize1280'), # 720
+        "video1920" => getSize('VideoSize1920'), # 1080
       }
-      
+
       # Add all our custom sizes
       for size in CUSTOM_SIZES
         h[size.name] = customSize(size.size)

--- a/_sass/_lightbox.sass
+++ b/_sass/_lightbox.sass
@@ -31,9 +31,10 @@
     -webkit-transform: rotate(360deg)
     transform: rotate(360deg)
 
-.lightbox-box__image
+.lightbox-box__content, .lightbox-box__image, .lightbox-box__video
   height: 100%
-  object-fit: contain
+  width: 100%
+  object-fit: scale-down
 
 .lightbox-box__load
   position: fixed

--- a/_shows/14_15/king_lear.md
+++ b/_shows/14_15/king_lear.md
@@ -107,8 +107,8 @@ assets:
     image: J4bNhcx
   - type: poster
     image: JXCJvSX
-
-
+  - type: trailer
+    video: kH5W832
 ---
 
 Widely regarded by scholars and academics as Shakespeare’s finest work, King Lear portrays a powerful king who loses his grip on everything that defines him. Along with Lear’s decline into madness, the play focuses on identity and morality as the state and royal family are torn apart.

--- a/feeds/smug_images.json
+++ b/feeds/smug_images.json
@@ -16,6 +16,13 @@
     "year_title": {{ show.year_page.title | jsonify }},
     "link": {{ show.url | jsonify }}
   }
+{% elsif asset.video %}
+  {% unless first_actual %},{% endunless %}
+  {{ asset.video.key | jsonify }}: {
+    "title": {{ show.title | jsonify }},
+    "year_title": {{ show.year_page.title | jsonify }},
+    "link": {{ show.url | jsonify }}
+  }
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/util/smug-show-videos.html
+++ b/util/smug-show-videos.html
@@ -1,0 +1,23 @@
+---
+body_class: util-smug-album
+---
+<h1>Smug Show Videos</h1>
+<p><em>The table may take several seconds to populate.</em></p>
+
+<table id="smug-images" data-album="j3PdMh" class="tablesorter">
+
+    <thead>
+        <tr><th>Thumbnail</th><th>Title</th><th>Filename</th><th>ImageKey</th><th>Usage</th></tr>
+    </thead>
+
+    <tbody>
+
+    </tbody>
+
+</table>
+
+<script src="/js/lib.js"></script>
+<script src="/js/utility.js"></script>
+<script src="/lib/tablesorter/dist/js/jquery.tablesorter.js"></script>
+
+<link rel="stylesheet" type="text/css" href="/lib/tablesorter/dist/css/theme.default.min.css" />


### PR DESCRIPTION
- [x] Add a `video` attribute to the show `assets:` list.
- [x] Fetch video URL from SmugImage
- [x] Add support for video playback in lightbox
- [ ] Make obvious that asset is video in thumbnail
- [x] Add smug-video ID lookup util
- [ ] Add all videos we have currently