### PR TITLE
Add YAML linting via python yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  trailing-spaces: false
+  indentation: false
+  line-length: false

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ and view the site on your local machine in an environment as close to the produc
 - `cd history-project` to change into the directory.
 - Type `./run_dev.sh`
 
-Once everything has finished running, you should see the site at `http://localhost:8000`. Hit 
+Once everything has finished running, you should see the site at `http://localhost:8000`. Hit
 <kbd>ctrl</kbd>+<kbd>c</kbd> to stop the server. If using 'Docker Toolbox' and `localhost` doesn't work, you can find the IP address of the virtual machine by running `echo " $(docker-machine ip default)"`
 
 By default `./run_dev.sh` uses the parameters `start` `install` `build` `test` `serve` in that order.
@@ -67,13 +67,19 @@ By default `./run_dev.sh` uses the parameters `start` `install` `build` `test` `
 - `stop` halts and destroys the docker container. You will need to run `start` and `install` again after running this
 
 You can add/remove steps to `./run_dev` as needed. For example, there is no need to run `start` or `install`
-every time you want to build the site. 
+every time you want to build the site.
 
 Environment variables (such as the Smugmug API key) can be changed by modifying the `ENV` lines in the Dockerfile (and then running `start` again).
 
 ## Editing
 
 See the [site documentation](https://history.newtheatre.org.uk/docs/).
+
+## Testing
+
+After building the site you can run the test suite with `gulp test`. Bear in mind you may want to disable htmltest's external link checking as this may take some time on a consumer internet connection.
+
+You may also test the syntax of YAML front-matter via `gulp yamllint`.
 
 ## Asset Storage
 

--- a/_bin/yamllint.sh
+++ b/_bin/yamllint.sh
@@ -1,33 +1,49 @@
 #!/bin/bash
 
 TESTDIR=tmp/yamllint
+PASS=true
+
+# Track exit codes, if one fails then whole script should fail
+function trackFail {
+    if [[ $? != 0 ]]; then
+        PASS=false
+    fi
+}
 
 # Clear last run
 rm -rf $TESTDIR
 
 # Test datafiles
 yamllint _data/
+trackFail $?
 
 # Remove all markdown content, anything after the second ---
 for fn in $(find . -name '*.md' -or -name '*.html' | egrep "^(./_committees|./_content|./_people|./_shows|./_venues)"); do
     # https://askubuntu.com/questions/642153/how-do-i-delete-everything-after-second-occurrence-of-quotes-using-the-command-l
     # sed -i -r 'H;1h;$!d;x; s/(([^---]*"){2}).*/\1/' $fn
-    mkdir -p `dirname $TESTDIR/$fn`
-    awk -v RS='---' -v ORS='---' 'NR==1{print} NR==2{print; printf"\n";exit}' $fn > $TESTDIR/$fn
+    mkdir -p $(dirname "$TESTDIR/$fn")
+    awk -v RS='---' -v ORS='---' 'NR==1{print} NR==2{print; printf"\n";exit}' "$fn" > "$TESTDIR/$fn"
 done
 
 # Loop over directories containing *.md files, this reduces the number of times
 # we need to start up yamllint.
-for dir in $(find $TESTDIR -type d)
+for dir in $(find "$TESTDIR" -type d)
 do
     # Only run if $dir contains *.md files
-    mdfiles=(`find $dir -maxdepth 1 -name "*.md"`)
+    mdfiles=($(find "$dir" -maxdepth 1 -name "*.md"))
     if [ ${#mdfiles[@]} -gt 0  ]; then
-        yamllint $dir/*.md
+        yamllint "$dir"/*.md
+        trackFail $?
     fi
     # Only run if $dir contains *.html files
-    htmltest=(`find $dir -maxdepth 1 -name "*.html"`)
+    htmltest=($(find "$dir" -maxdepth 1 -name "*.html"))
     if [ ${#htmltest[@]} -gt 0  ]; then
-        yamllint $dir/*.html
+        yamllint "$dir"/*.html
+        trackFail $?
     fi
 done
+
+if [[ $PASS == false ]]; then
+    exit 1
+fi
+

--- a/_bin/yamllint.sh
+++ b/_bin/yamllint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TESTDIR=tmp/yamllint
+
+# Clear last run
+rm -rf $TESTDIR
+
+# Test datafiles
+yamllint _data/
+
+# Remove all markdown content, anything after the second ---
+for fn in $(find . -name '*.md' -or -name '*.html' | egrep "^(./_committees|./_content|./_people|./_shows|./_venues)"); do
+    # https://askubuntu.com/questions/642153/how-do-i-delete-everything-after-second-occurrence-of-quotes-using-the-command-l
+    # sed -i -r 'H;1h;$!d;x; s/(([^---]*"){2}).*/\1/' $fn
+    mkdir -p `dirname $TESTDIR/$fn`
+    awk -v RS='---' -v ORS='---' 'NR==1{print} NR==2{print; printf"\n";exit}' $fn > $TESTDIR/$fn
+done
+
+# Loop over directories containing *.md files, this reduces the number of times
+# we need to start up yamllint.
+for dir in $(find $TESTDIR -type d)
+do
+    # Only run if $dir contains *.md files
+    mdfiles=(`find $dir -maxdepth 1 -name "*.md"`)
+    if [ ${#mdfiles[@]} -gt 0  ]; then
+        yamllint $dir/*.md
+    fi
+    # Only run if $dir contains *.html files
+    htmltest=(`find $dir -maxdepth 1 -name "*.html"`)
+    if [ ${#htmltest[@]} -gt 0  ]; then
+        yamllint $dir/*.html
+    fi
+done

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -171,6 +171,8 @@ gulp.task('index_inc', ['S_index_search_inc', 'S_index_people_inc'])
 
 gulp.task('htmltest', shell.task(['_bin/htmltest']));
 
+gulp.task('yamllint', shell.task(['_bin/yamllint.sh']));
+
 function feedlint() {
     return gulp.src('_site/feeds/*.json')
                .pipe(jsonlint())


### PR DESCRIPTION
Implement a script `_bin/yamllint.sh` that runs all datafiles and just the frontmatter of *.md and *.html files through python yamllint.

<del>Add this test to the build step of the deployment. Can run alongside all other tasks to reduce slowdown. </del>

I've turned off testing for trailing spaces, indentation and line-length. There's a lot of these and they don't matter _that_ much. 

- I intend to keep line-length off. Hard-wraps are ok when you're not going to edit the text after the fact, but are a huge PITA if you do.
- Trailing spaces will eventually be turned on. Some editors remove them automatically and this muddies diffs.
- Indentation will eventually be turned on. I'll do that all in one go for neatness.


Current state of linter output / things to fix: https://gist.github.com/wjdp/47e192fd3c47cf43b909a1656964c11b