### PR TITLE
Switch to showing focus state using focus-ring

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -46,5 +46,6 @@
   <!-- Scripts -->
   <script defer type="text/javascript" src="{% static /js/lib.js %}"></script>
   <script defer type="text/javascript" src="/js/raven.js"></script>
+  <script defer type="text/javascript" src="/js/focus-ring.js"></script>
   <script defer type="text/javascript" src="{% static /js/app.js %}"></script>
 </head>

--- a/_includes/svg/year-graph.html
+++ b/_includes/svg/year-graph.html
@@ -5,7 +5,7 @@
      preserveAspectRatio="none"
      xmlns="http://www.w3.</2000/svg">
   {% for col in site.data.year-graph.graph %}
-  <a xlink:href="{{ col.year.url }}">
+  <a xlink:href="{{ col.year.url }}" tabindex="-1">
     <rect class="decade-col-{{ col.year.decade }}"
           x="{{ col.x }}"
           y="{{ col.y }}"

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -148,35 +148,34 @@ body_class: layout-person header-nobr content-nobr
   <section class="person-shows">
     {% for record in person.shows %}
     <div class="person-show">
-      <div class="person-show-poster">
-        <a href="{{ record.item.url }}" title="{{ record.item.title | escape_once }}">
-        {% if record.item.poster %}
-          {% include images/show-poster-thumb.html
-                     image=record.item.poster
-                     sizes="(max-width: 420px) 50vw, (max-width: 768px) 33vw, 170px"
-                     alt=record.item.title
-                     lazy=true %}
-        {% else %}
-          <!-- Missing Poster -->
-        {% endif %}
-        </a>
-      </div>
+      <a href="{{ record.item.url }}" title="{{ record.item.title | escape_once }}">
+        <div class="person-show-poster">
+          {% if record.item.poster %}
+            {% include images/show-poster-thumb.html
+                       image=record.item.poster
+                       sizes="(max-width: 420px) 50vw, (max-width: 768px) 33vw, 170px"
+                       alt=record.item.title
+                       lazy=true %}
+          {% else %}
+            <!-- Missing Poster -->
+          {% endif %}
+        </div>
 
-      <h3 class="person-show-title">
-        {{ record.item.title | escape_once }}
-      </h3>
+        <h3 class="person-show-title">
+          {{ record.item.title | escape_once }}
+        </h3>
 
-      <div class="person-show-meta">
-        <span class="person-show-season season-{{ record.item.season | downcase | replace:" ","-" }}" title="{{ record.item.season }}"></span>
-        <span class="person-show-year">{{ record.item.year_page.title }}</span>
-      </div>
+        <div class="person-show-meta">
+          <span class="person-show-season season-{{ record.item.season | downcase | replace:" ","-" }}" title="{{ record.item.season }}"></span>
+          <span class="person-show-year">{{ record.item.year_page.title }}</span>
+        </div>
 
-      <ul class="person-show-roles">
-      {% for role in record.roles %}
-        <li>{{ role | escape_once }}</li>
-      {% endfor %}
-      </ul>
-
+        <ul class="person-show-roles">
+        {% for role in record.roles %}
+          <li>{{ role | escape_once }}</li>
+        {% endfor %}
+        </ul>
+      </a>
     </div>
     {% endfor %}
   </section>

--- a/_sass/_archives.sass
+++ b/_sass/_archives.sass
@@ -36,9 +36,6 @@
       padding: $baseline / 2
       background: lighten($color-background, 3%)
       // Make focus less spaz
-      @include no-focus
-      &:focus
-        background: lighten($color-background, 12%)
 
 
 .decade-list

--- a/_sass/_breadcrumbs.sass
+++ b/_sass/_breadcrumbs.sass
@@ -51,11 +51,8 @@ $focus-color: lighten($color-1, 15%)
 
     @include no-underline
 
-    &:focus
-      outline: none
-      background: $focus-color
-    &:focus:after
-      border-left-color: $focus-color
+    // Normal focus state does not work, add some more
+    @include extra-focus
 
   li a:after
     content: " "
@@ -71,7 +68,6 @@ $focus-color: lighten($color-1, 15%)
     left: 100%
     z-index: 2
 
-
   li a:before
     content: " "
     display: block
@@ -86,7 +82,6 @@ $focus-color: lighten($color-1, 15%)
     margin-left: 2px
     left: 100%
     z-index: 1
-
 
   li:first-child a
     padding-left: 10px
@@ -125,6 +120,9 @@ $focus-color: lighten($color-1, 15%)
 
     @include no-underline
 
+    // Normal focus state does not work, add some more
+    @include extra-focus
+
     &.disabled
       background: darken($color-1, 3%)
       color: lighten($color-1, 6%)
@@ -132,11 +130,6 @@ $focus-color: lighten($color-1, 15%)
     &.enabled:hover
       background: darken($color-1, 6%)
 
-    &:focus
-      background: $focus-color !important
-      outline: none
-    &:focus:after
-      border-left-color: $focus-color !important
 
 @mixin breadcrumb-color($i, $color)
   // HACK, cos the thing we need to override is quite specific

--- a/_sass/_buttons.sass
+++ b/_sass/_buttons.sass
@@ -39,8 +39,6 @@
     outline: 0
     margin-bottom: $baseline + 1
 
-  @include block-focus
-
 .button-primary, .button-search
   @include button(lighten($color-info, 20%))
 

--- a/_sass/_debug.sass
+++ b/_sass/_debug.sass
@@ -51,10 +51,6 @@ $debug-data-term-width: 20%
       min-height: 1em + 0.5em*2
       max-height: 6em
       overflow: hidden
-      &:focus
-        max-height: none
-        background: mix($color-debug-attr-base, black)
-        color: white
 
     .debug-data__value--true
       color: #bcff00

--- a/_sass/_docs.sass
+++ b/_sass/_docs.sass
@@ -53,10 +53,6 @@ $inner-width: 87%
       font-size: $base-font-size * 0.8
       @include no-underline
 
-      &:focus
-        outline: none
-        background: mix($color-focus, $color-nnt-purple)
-
     &.current
       background: darken($color-nnt-purple, 22%)
       a

--- a/_sass/_forms.sass
+++ b/_sass/_forms.sass
@@ -1,7 +1,6 @@
 // Forms
 
 input, textarea, select
-  @include block-focus
   // Bugfix safari input shittyness, see #635
   -moz-appearance: none
   -webkit-appearance: none
@@ -40,8 +39,6 @@ input[type=checkbox]
   @include text-shadow-effect($bg)
 
   position: relative
-
-  @include block-focus
 
   &:active
     top: 1px

--- a/_sass/_header.sass
+++ b/_sass/_header.sass
@@ -48,7 +48,6 @@ $nav-height-land: 73px
   display: block
   flex: 1
 
-  @include no-focus
   &:focus
     .nnt-logo
       .nnt-logo_big
@@ -166,19 +165,14 @@ $title-text-baseline: 1.2
       &.current
         background: darken($color-nnt-purple, 10%)
 
-      @include no-focus
-      &:hover
-        background: $color-focus
-
     // Desktop nav styling
     @include respond-up(tab-port)
       padding-bottom: 3px
       &.current .page-link-text
         // Purple underline for current section
         border-bottom: 2px solid $color-nnt-purple
-      @include no-focus
-      &:hover .page-link-text, &.current:focus .page-link-text, &:focus .page-link-text
-        // White underline for hover and current focus state
+      &:hover .page-link-text
+        // White underline for hover
         border-bottom: 2px solid $color-text-white
 
 .site-search-show
@@ -246,8 +240,6 @@ $title-text-baseline: 1.2
   &:placeholder
     color: rgba($color-text-black, 0.3)
 
-  @include no-focus
-
   @include respond-up(tab-port)
     padding: 6px
     padding-left: 32px
@@ -260,9 +252,6 @@ $title-text-baseline: 1.2
 
     &:placeholder
       color: rgba($color-text-white, 0.25)
-
-    // Re-enable as disable by default
-    @include block-focus
 
 .site-search-submit
   display: none

--- a/_sass/_layout.sass
+++ b/_sass/_layout.sass
@@ -85,10 +85,6 @@ body
   clip: rect(1px 1px 1px 1px) /* IE6, IE7 */
   clip: rect(1px, 1px, 1px, 1px)
 
-@mixin block-focus
-  &:focus
-    outline: 6px solid $color-focus
-
 .banner-header
   @include grid-wrap
   background: $color-grey

--- a/_sass/_people-grid.sass
+++ b/_sass/_people-grid.sass
@@ -53,16 +53,6 @@
     a
       width: 100%
 
-      @include no-focus
-      &:focus
-        .person-headshot-placeholder
-          // Tint background of silhouette
-          background: $color-focus
-
-        .name
-          // Apply focus style to text
-          @include link-focus
-
   .name
     text-align: center
     color: $color-text-white
@@ -108,10 +98,6 @@
   //       background: transparent
   //       border-color: transparent
   //       color: transparent
-
-  //     &:focus
-  //       // FIXME provide a focus state
-  //       outline: none
 
   //     &::-webkit-slider-thumb, &::-moz-slider-thumb, &::-ms-slider-thumb
   //       -webkit-appearance: none

--- a/_sass/_person-list.sass
+++ b/_sass/_person-list.sass
@@ -16,7 +16,6 @@
     // Ensure container is exactly two lines high, at least
     display: block
     min-height: $person-list-baseline * 2 + $baseline / 2
-    overflow: hidden
 
     i
       position: absolute
@@ -67,6 +66,7 @@
     font-weight: $person-role-weight
 
   a
+    display: block
     color: $color-text-white
 
     .person-role
@@ -77,7 +77,3 @@
     &:hover
       .person-name
         text-decoration: underline // Only underline name
-
-    @include no-focus
-    &:focus .person-name-underline
-      @include link-focus

--- a/_sass/_person.sass
+++ b/_sass/_person.sass
@@ -179,6 +179,15 @@
     @include respond-up(tab-port)
       max-width: 190px
 
+    a
+      display: block
+
+      // Contains many content items, make look normal
+      color: $color-text-white
+      font-weight: normal
+
+      @include no-underline
+
     .person-show-poster
       // 2 wide
       height: 62vw
@@ -192,21 +201,7 @@
       margin-bottom: 4px
       overflow: hidden
       background: #0D0D0D
-      a
-        // Make whole element a block
-        display: block
-        height: 100%
 
-        @include no-underline
-        @include block-focus
-
-        &:focus
-          // Set whole element background to focus
-          background: $color-focus
-          outline: none
-          img
-            // Semi-trans the image so you can see the colour thru it
-            opacity: 0.4
       img
         width: 100%
 

--- a/_sass/_playwrights.sass
+++ b/_sass/_playwrights.sass
@@ -32,11 +32,6 @@ $color-plays: lighten($color-playwright, 15%)
 
     border-bottom: 2px dotted mix($color-plays, black, 80%)
 
-    @include no-focus
-
-    &:focus
-      border-bottom: 2px dotted mix($color-plays, white, 80%)
-
     option
       background: $color-plays
 
@@ -112,10 +107,6 @@ $color-plays: lighten($color-playwright, 15%)
         padding-left: 0.3em + $poster-width
         margin-bottom: $baseline / 3
 
-        a:focus .playwright-show-title
-          background: red
-          @include link-focus
-
         .playwright-list-poster
           position: absolute
           top: 0
@@ -137,6 +128,10 @@ $color-plays: lighten($color-playwright, 15%)
           font-weight: normal
           font-size: 0.7em
           color: mix($color-grey, $color-background)
+
+        a
+          // Enable good focus state
+          display: block
 
         a:hover
           text-decoration: none

--- a/_sass/_search.sass
+++ b/_sass/_search.sass
@@ -40,10 +40,10 @@
       border-bottom: 1px solid $color-white
       margin-bottom: 1px
 
-      @include no-focus
       &:focus
         border-bottom-width: 2px
         margin-bottom: 0px
+        outline: none
 
 .search-results
   @include grid-wrap

--- a/_sass/_type.sass
+++ b/_sass/_type.sass
@@ -151,15 +151,6 @@ $link-border-bottom-opacity: 0.2
     color: lighten($color, 20%)
     text-decoration: underline
 
-@mixin link-focus
-  background: $color-focus
-  outline: 4px solid $color-focus
-
-@mixin no-focus
-  &:focus
-    background: none
-    outline: none
-
 @mixin no-underline($on-hover: false)
   // No underlines on normal and hover states
   text-decoration: none
@@ -173,14 +164,6 @@ a
   font-weight: $font-weight-bold
   @include link-colour($color-link)
 
-  &:focus
-    @include link-focus
-
-@mixin anti-content-a-hover
-  background: inherit
-  margin: inherit
-  padding: inherit
-
 a.pagelink
   &:before
     // content: "\x9B "
@@ -189,6 +172,60 @@ a.pagelink
 
 .bracketed
   color: $color-grey
+
+// FOCUS STATE
+
+// Following advice from Google's a11y cast [1] we remove the outline by default
+// to provide a better experience for mouse users. The psuedo-class :focus-ring
+// then re-adds it when navigating via the keyboard. This is a new feature and
+// isn't well supported, so we use a polyfill [2] which uses the class .focus-
+// ring instead of the pseudo element.
+
+// [1]: https://www.youtube.com/watch?v=ilj2P5-5CjI&list=PLNYkxOF6rcICWx0C9LVWWVqvHlYJyqw7g&index=1
+// [2]: https://github.com/WICG/focus-ring
+
+// Getting weird behaviour with Sass and the :focus selector. It doesn't like
+// :focus-ring, .focus-ring, appears to be moving the colon around. It really
+// doesn't like :focus:not(:focus-ring)! Focus cannot exist outside of another
+// selector???
+
+// Riiight: seems like sass needs a backslash at the start of the line
+// Also seems that browsers (Chrome) ignore the whole selector if it contains
+// something it doesn't understand (:focus-ring), eugh. Have to separate
+// selectors.
+
+@mixin focus-ring
+  outline: 3px dashed $color-focus
+  outline-offset: 2px
+
+\:focus:not(:focus-ring)
+  outline: none
+
+\:focus:not(.focus-ring)
+  outline: none
+
+\:focus-ring
+  @include focus-ring
+
+.focus-ring
+  @include focus-ring
+
+// Focus for form fields and the like. Shows to all users, so make less
+// obnoxious (yet still useful).
+@mixin field-focus
+  &:focus
+    outline: 6px solid rgba($color-focus, 0.4)
+    outline-offset: 0
+
+input[type=text], input[type=search], input[type=number], input[type=date],
+input[type=time], input[type=datetime], textarea
+  @include field-focus
+
+// For places where the normal focus doesn't quite cut it
+@mixin extra-focus
+  &.focus-ring
+    background: white !important
+    color: black !important
 
 // INLINE STYLES
 

--- a/_sass/_year-graph.sass
+++ b/_sass/_year-graph.sass
@@ -27,6 +27,3 @@
     $shift-color: adjust-hue($background-base, $shift)
 
     @include decade-col-fill($i, $shift-color)
-
-  a
-    @include no-focus

--- a/_sass/main.sass
+++ b/_sass/main.sass
@@ -30,8 +30,7 @@ $color-background-alt: darken($color-nnt-purple, 23%)
 $color-link: #FFC425
 $color-link-visited: darken($color-link, 07%)
 $color-link-bg-hover: darken($color-nnt-purple, 20%)
-$color-focus: rgba($color-text-white, 0.3)
-
+$color-focus: $color-text-white
 $color-decades-base: #601111
 
 $color-error: #601111

--- a/js/focus-ring.js
+++ b/js/focus-ring.js
@@ -1,0 +1,71 @@
+/* https://github.com/WICG/focus-ring */
+
+// Polyfill for :focus-ring state. Modified for this project to work with
+// turbolinks
+
+document.addEventListener('turbolinks:load', function() {
+    var hadKeyboardEvent = false,
+        keyboardModalityWhitelist = [ 'input:not([type])',
+                                      'input[type=text]',
+                                      'input[type=number]',
+                                      'input[type=date]',
+                                      'input[type=time]',
+                                      'input[type=datetime]',
+                                      'textarea',
+                                      '[role=textbox]' ].join(','),
+        isHandlingKeyboardThrottle,
+        matcher = (function () {
+        var el = document.body;
+        if (el.matchesSelector)
+        return el.matchesSelector;
+        if (el.webkitMatchesSelector)
+        return el.webkitMatchesSelector;
+        if (el.mozMatchesSelector)
+        return el.mozMatchesSelector;
+        if (el.msMatchesSelector)
+        return el.msMatchesSelector;
+        console.error('Couldn\'t find any matchesSelector method on document.body.');
+    }()),
+    focusTriggersKeyboardModality = function (el) {
+        var triggers = false;
+        if (matcher) {
+        triggers = matcher.call(el, keyboardModalityWhitelist) && matcher.call(el, ':not([readonly]');
+        }
+        return triggers;
+    },
+        addFocusRingClass = function(el) {
+            if (el.classList.contains('focus-ring'))
+                return;
+            el.classList.add('focus-ring');
+            el.setAttribute('data-focus-ring-added', '');
+        },
+        removeFocusRingClass = function(el) {
+            if (!el.hasAttribute('data-focus-ring-added'))
+                return;
+            el.classList.remove('focus-ring');
+            el.removeAttribute('data-focus-ring-added')
+        };
+
+    document.body.addEventListener('keydown', function() {
+        hadKeyboardEvent = true;
+        if (document.activeElement.matches(':focus')) {
+            addFocusRingClass(document.activeElement);
+        }
+        if (isHandlingKeyboardThrottle) {
+            clearTimeout(isHandlingKeyboardThrottle);
+        }
+        isHandlingKeyboardThrottle = setTimeout(function() {
+            hadKeyboardEvent = false;
+        }, 100);
+    }, true);
+
+    document.body.addEventListener('focus', function(e) {
+        if (!hadKeyboardEvent && !focusTriggersKeyboardModality(e.target))
+            return;
+        addFocusRingClass(e.target);
+    }, true);
+
+    document.body.addEventListener('blur', function(e) {
+        removeFocusRingClass(e.target)
+    }, true);
+});


### PR DESCRIPTION
The pseudo-selector :focus-ring allows for showing a 'focus-ring' when navigating with the keyboard but without showing it for mouse users. This means we can make the focus-ring obnoxiously obvious without sacrificing aesthetics for mouse users.

![image](https://cloud.githubusercontent.com/assets/1690934/24314141/0ca6c95c-10d8-11e7-88fb-e7b5092223b8.png)

As [:focus-ring][1] is very new (so new it's not even on caniuse.com yet—we be hipster), we needs a [polyfill][2]. Add this.
    
See [Google's a11y cast video for implementation description][3].
    
#### Other bits
- Remove a lot of custom focus behaviour, lower maintainence, more central control. Some elements required the `a` having display: block set on it when it's above a block level element to show the focus ring properly.
- Disable tabbing on SVG year-graph links, not useful
- Implement whole show linking on people page. Will close #691, sorry but this will close #744. It needed to be done for this PR.

[1]: https://drafts.csswg.org/selectors-4/#the-focusring-pseudo
[2]: https://github.com/WICG/focus-ring
[3]: https://www.youtube.com/watch?v=ilj2P5-5CjI&list=PLNYkxOF6rcICWx0C9LVW