### PR TITLE
Adding SJP and CCP to exclude list

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -5,6 +5,8 @@ IgnoreURLs:
 - "photos.smugmug.com"
 - "photos.newtheatre.org.uk"
 - "archive.is"
+- "castingcallpro.com"
+- "stagejobspro.com"
 IgnoreDirs:
 - "^lib"
 


### PR DESCRIPTION
Should stop links to stagejobspro and castingcallpro erroring in htmltest