### PR TITLE
Refactor/show link list

### DIFF
--- a/_data/link-types.yaml
+++ b/_data/link-types.yaml
@@ -24,5 +24,7 @@
 
 - type: Article
   icon: fa fa-newspaper-o
+  is_news: true
 - type: Review
   icon: fa fa-newspaper-o
+  is_news: true

--- a/_layouts/show.html
+++ b/_layouts/show.html
@@ -266,10 +266,6 @@ body_class: section-archives layout-show
     </section>
   </div>
 
-  <div class="show-footer">
-    <!-- <a href="https://github.com/newtheatre/history-project/blob/gh-pages/{{show.path}}">https://github.com/newtheatre/history-project/blob/gh-pages/_{{show.url}}</a -->
-  </div>
-
 </div>
 
 <script type="text/javascript">

--- a/_people/martha_wilson.md
+++ b/_people/martha_wilson.md
@@ -6,6 +6,7 @@ headshot: HgShCtM
 news:
   - type: Article
     title: "Daring dozen: Old Vic talent list includes director who made secret Syria trip"
+    publisher: London Evening Standard
     date: 2015-11-26
     href: "http://www.standard.co.uk/goingout/theatre/daring-dozen-old-vic-talent-list-includes-director-who-made-secret-syria-trip-a3123711.html"
     snapshot: Lpoqn

--- a/_plugins/link_list.rb
+++ b/_plugins/link_list.rb
@@ -12,10 +12,9 @@ module LinkList
       # Select link type from data path or fallback on default
       @link_type = @site.data['link-types'].select {
         |i| i['type'] == link_hash['type'] }[0]
-      if @link_type.nil?
-        @link_type = @site.data['link-types'].select {
+      @link_type_default = @site.data['link-types'].select {
           |i| i['type'] == "default" }[0]
-      end
+      @link_type ||= @link_type_default
     end
 
     def type
@@ -76,7 +75,7 @@ module LinkList
     end
 
     def icon
-      @link_hash['icon'] || @link_type['icon']
+      @link_hash['icon'] || @link_type['icon'] || @link_type_default['icon']
     end
 
     def data

--- a/_plugins/people.rb
+++ b/_plugins/people.rb
@@ -141,10 +141,10 @@ module Jekyll
       person.data["has_bio"] = person.content.length > 0
 
       # Person link lists
-      person.data["links"] = LinkList::LinkList.new(@site, person.data["links"])
-      @site.data['link-register'].add_list(person.data["links"], person)
-      person.data["news"] = LinkList::LinkList.new(@site, person.data["news"])
-      @site.data['link-register'].add_list(person.data["news"], person)
+      person.data["links"] = LinkList::LinkList.new(@site, person.data["links"], person)
+      @site.data['link-register'].add_list(person.data["links"])
+      person.data["news"] = LinkList::LinkList.new(@site, person.data["news"], person)
+      @site.data['link-register'].add_list(person.data["news"])
 
       # People by filename
       @people_by_filename[person.basename_without_ext] = person

--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -198,6 +198,11 @@ module Jekyll
       show.data["poster"] = display_image
       show.data["display_image"] = display_image
 
+      if show.data.key?("links")
+        show.data["links"] = LinkList::LinkList.new(@site, show.data["links"])
+        @site.data['link-register'].add_list(show.data["links"], show)
+      end
+
       # Set ignore_missing if not already
       show.data["ignore_missing"] ||= ignore_missing(show)
     end

--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -199,8 +199,8 @@ module Jekyll
       show.data["display_image"] = display_image
 
       if show.data.key?("links")
-        show.data["links"] = LinkList::LinkList.new(@site, show.data["links"])
-        @site.data['link-register'].add_list(show.data["links"], show)
+        show.data["links"] = LinkList::LinkList.new(@site, show.data["links"], show)
+        @site.data['link-register'].add_list(show.data["links"])
       end
 
       # Set ignore_missing if not already


### PR DESCRIPTION
- Switch show link list to use the LinkList plugin, was just passing through raw. Will close #842.
- Add better error handling to link lists. Now complains with good messages including document filename when missing `type`, `href`/`username` and publisher when Article / Review.