### PR TITLE
Group venues by city

### DIFF
--- a/_content/archives.html
+++ b/_content/archives.html
@@ -75,17 +75,14 @@ permalink: /years/
   <div class="others">
     <div class="archive-section venues" id="venues">
       <h3>Venues</h3>
-      <div class="archive-section-content">
-        <ul class="venue-list archive-list">
-          {% for item in site.venues %}
-          <li {% if item.shows.size < 2 %}class="debug debug-hidden-content" data-debug-toggle{% endif %}>
-            <a href="{{ item.url }}">{{ item.title }}</a>
-            <div class="decade-list-counts archive-list-counts" data-debug-toggle title="Show counts for venue">
-              {% if item.shows %}{{ item.show_count }}{% endif %}
-            </div>
-          </li>
-          {% endfor %}
-        </ul>
+      <div class="archive-section-content venue-listing">
+        <div class="venue-listing__city venue-listing__city--nottingham">
+          {% include venue-list.html city='Nottingham' %}
+        </div>
+        <div class="venue-listing__city">
+          {% include venue-list.html city='Edinburgh' %}
+          {% include venue-list.html city=nil %}
+        </div>
       </div>
     </div>
     <div class="archive-section seasons" id="seasons">

--- a/_data/defs/venue.yaml
+++ b/_data/defs/venue.yaml
@@ -30,6 +30,21 @@
   short: Exact location of the venue
   description: "Hash with two keys: `lat` and `lon` as decimals. Used for map marker."
 
+- attr: city
+  type: string
+  short: City
+  description: "City where the venue is located."
+
+- attr: city_sort
+  type: string
+  short: City grouping
+  description: "Used for mapping venues to listings on archive page."
+  generated: true
+
+- attr: sort
+  type: number
+  short: Allows manual sorting of venue listing
+
 - attr: shows
   type: documentarray
   short: List of shows performed in this venue

--- a/_includes/venue-list.html
+++ b/_includes/venue-list.html
@@ -1,0 +1,16 @@
+{% unless include.city == nil %}
+  <h4 class="venue-listing__city-title">{{ include.city }}</h4>
+  {% else %}
+  <h4 class="venue-listing__city-title debug debug-hidden-content" data-debug-toggle><em>Other</em></h4>
+{% endunless %}
+
+<ul class="venue-list archive-list {% unless include.city == 'Nottingham' %}archive-list--single{% endunless %}">
+  {% for item in site.data.venues_by_city[include.city] %}
+    <li {% unless item.is_listed %}class="debug debug-hidden-content" data-debug-toggle{% endunless %}>
+      <a href="{{ item.url }}">{{ item.title_short }}</a>
+      <div class="decade-list-counts archive-list-counts" data-debug-toggle title="Show counts for venue">
+        {% if item.shows %}{{ item.show_count }}{% endif %}
+      </div>
+    </li>
+  {% endfor %}
+</ul>

--- a/_layouts/venue.html
+++ b/_layouts/venue.html
@@ -18,6 +18,7 @@ class: venue
     {{ page.content }}
     <div class="venue-info__meta">
       {% if page.built %}<span><i class="ion-calendar"></i> {{ page.built }}</span>{% endif %}
+      {% if page.city %}<span><i class="fa fa-building"></i> {{ page.city }}</span>{% endif %}
       <span><i class="fa fa-ticket"></i> {{ page.shows.size }} shows</span>
     </div>
   </div>
@@ -32,9 +33,11 @@ class: venue
     {% endif %}
   </div>
 
+  {% if page.location %}
   <div class="venue-map venue-header__col">
     {% include elements/map.html location=page.location %}
   </div>
+  {% endif %}
 </div>
 
 {% endunless %}

--- a/_sass/_archives.sass
+++ b/_sass/_archives.sass
@@ -39,6 +39,8 @@
       background: lighten($color-background, 3%)
       // Make focus less spaz
 
+.archive-list--single
+  columns: 1
 
 .decade-list
   @include respond-up(tab-land)
@@ -107,8 +109,29 @@ $background-items: -3
     h3
       border-bottom-color: $color-venues
 
-  .venue-list
-    columns: 3 12rem
+  .venue-listing
+    display: flex
+    flex-wrap: wrap
+
+  .venue-listing__city
+    @include block
+    width: 100%
+    @include respond-up(tab-port)
+      width: 100%
+    @include respond-up(tab-land)
+      width: 100% * 1/3
+      @include set-property-to-gutter(padding-right)
+
+    &:last-child
+      padding-right: 0
+
+  .venue-listing__city--nottingham
+    @include respond-up(tab-land)
+      width: 100% * 2/3
+
+  .venue-listing__city-title
+    font-size: 1.1rem
+    margin-bottom: 0.25rem
 
   .seasons
     h3

--- a/_sass/main.sass
+++ b/_sass/main.sass
@@ -44,7 +44,7 @@ $color-grey-dark:  darken($color-grey, 25%)
 
 $color-selection: $color-nnt-orange
 
-$color-empty-poster: mix($color-black, $color-background, 30%)
+$color-empty-poster: mix($color-black, $color-background, 90%)
 
 $color-venues: #4D8E13
 $color-seasons: #134466

--- a/_shows/13_14/the_rehearsal.md
+++ b/_shows/13_14/the_rehearsal.md
@@ -7,7 +7,7 @@ season_sort: 215
 date_start: 2014-03-10
 date_end: 2014-03-11
 venue: New Theatre Backstage
-venue_sort: New Theatre Studios
+venue_sort: New Theatre Studio A
 
 cast:
   - role: Al

--- a/_shows/14_15/paper_productions_present_the_rehearsal.md
+++ b/_shows/14_15/paper_productions_present_the_rehearsal.md
@@ -8,7 +8,7 @@ season_sort: 210
 date_start: 2015-01-28
 date_end: 2015-01-31
 venue: New Theatre Backstage
-venue_sort: New Theatre Studios
+venue_sort: New Theatre Studio A
 canonical:
   - title: The Rehearsal
 
@@ -41,7 +41,7 @@ crew:
     name: Joseph Heil
   - role: Venue Technician
     name: Nathan Penney
-    
+
 assets:
   - type: poster
     image: 7jB75Hp

--- a/_shows/15_16/strangers.md
+++ b/_shows/15_16/strangers.md
@@ -5,7 +5,7 @@ season: Fringe
 season_sort: 90
 period: Autumn
 venue: New Theatre Studio A and B
-venue_sort: New Theatre Studios
+venue_sort: New Theatre Studio A
 date_start: 2015-11-29
 date_end: 2015-11-30
 

--- a/_shows/16_17/blue_stockings.md
+++ b/_shows/16_17/blue_stockings.md
@@ -4,7 +4,7 @@ playwright: Jessica Swale
 season: Lakeside
 season_sort: 340
 period: Spring
-venue: Lakeside
+venue: Djanogly Theatre
 date_start: 2017-05-09
 date_end: 2017-05-13
 
@@ -78,7 +78,7 @@ links:
   - type: Review
     href: http://www.hercampus.com/school/nottingham/review-blue-stockings-nottingham-new-theatre
     snapshot: gu8SG
-    publisher: HerCampus 
+    publisher: HerCampus
     author: Emily Brady
     title: "Review: Blue Stockings at Nottingham Lakeside Arts"
     date: 2017-05-11
@@ -101,7 +101,7 @@ links:
 It is 1896 and Tess has begun her education at Girton College, Cambridge – home to the country’s first female students and an object of contempt and derision for the rest of the university.
 
 Unable to graduate, yet matching their male peers grade for grade, Tess and her fellow students begin to notice their stigma as 'bluestockings' – unnatural, educated women. Endangered by their position as unqualified and unmarriagable, they must fight to change the history of education.
- 
+
 Facing economic difficulty, the distractions of love and senseless prejudice the women dare to confront outdated social practices in order to live life to the full. Blue Stockings follows the women over one tumultuous academic year, in their fight for the right to graduate.
- 
+
 In 2017, as new financial barriers to university spring up and the issue of women’s access to education all over the world is rarely off the news, many of the questions the play raises feel as significant and relevant now as ever.

--- a/_shows/51_52/the_changeling.md
+++ b/_shows/51_52/the_changeling.md
@@ -2,7 +2,7 @@
 title: The Changeling
 season: In House
 period: Autumn
-venue: Trent Great Hall
+venue: Trent, Great Hall
 playwright: Thomas Middleton and William Rowley
 season_sort: 10
 date_start: 1951-11-21

--- a/_venues/c-venues.md
+++ b/_venues/c-venues.md
@@ -1,0 +1,4 @@
+---
+title: C venues
+city: Edinburgh
+---

--- a/_venues/cephas-cellar.md
+++ b/_venues/cephas-cellar.md
@@ -1,0 +1,4 @@
+---
+title: Cephas Cellar
+city: Edinburgh
+---

--- a/_venues/cripps-hall.md
+++ b/_venues/cripps-hall.md
@@ -1,0 +1,4 @@
+---
+title: Cripps Hall
+city: Nottingham
+---

--- a/_venues/djanogly-theatre.md
+++ b/_venues/djanogly-theatre.md
@@ -1,7 +1,7 @@
 ---
-title: Djanogly Theatre 
-title_short: Djanogly Theatre
+title: Djanogly Theatre
 built: 2001
+city: Nottingham
 images:
   - sSSNNhX
 location:

--- a/_venues/greenside.md
+++ b/_venues/greenside.md
@@ -1,0 +1,4 @@
+---
+title: Greenside
+city: Edinburgh
+---

--- a/_venues/herriot-watt-building.md
+++ b/_venues/herriot-watt-building.md
@@ -1,0 +1,5 @@
+---
+title: Herriot Watt Building
+title_short: Herriot Watt
+city: Edinburgh
+---

--- a/_venues/lee-rosys-tea-rooms.md
+++ b/_venues/lee-rosys-tea-rooms.md
@@ -1,0 +1,5 @@
+---
+title: Lee Rosy's Tea Rooms
+title_short: Lee Rosy's
+city: Nottingham
+---

--- a/_venues/lenton.md
+++ b/_venues/lenton.md
@@ -1,0 +1,4 @@
+---
+title: Lenton
+city: Nottingham
+---

--- a/_venues/lincoln-library.md
+++ b/_venues/lincoln-library.md
@@ -1,12 +1,12 @@
 ---
-title: Lincoln Library 
-title_short: Lincoln Library
+title: Lincoln Library
 built: 1962
 images:
   - 5rTvvrw
 location:
   lat: 52.9419
   lon: -1.1995
+city: Nottingham
 ---
 
 Lincoln Library, also called Coveney Library, is a hall library located directly north of the New Theatre.

--- a/_venues/new-theatre-studio-a.md
+++ b/_venues/new-theatre-studio-a.md
@@ -7,6 +7,8 @@ images:
 location:
   lat: 52.938035
   lon: -1.196260
+city: Nottingham
+sort: 20
 ---
 
 Part of the Archaeology and Classics building left up when building was demolished.

--- a/_venues/new-theatre-studio-b.md
+++ b/_venues/new-theatre-studio-b.md
@@ -7,6 +7,8 @@ images:
 location:
   lat: 52.938035
   lon: -1.196260
+city: Nottingham
+sort: 30
 ---
 
 Part of the Archaeology and Classics building left up when building was demolished.

--- a/_venues/new-theatre.md
+++ b/_venues/new-theatre.md
@@ -1,5 +1,5 @@
 ---
-title: New Theatre 
+title: New Theatre
 title_short: New Theatre
 built: 1965
 images:
@@ -13,6 +13,8 @@ images:
 location:
   lat: 52.938035
   lon: -1.196260
+city: Nottingham
+sort: 10
 ---
 
 Originally part of the Archaeology and Classics building, the main auditorium of the Nottingham New Theatre was given to the company in 1965. The foyer was remodeled in 2001 and again in 2012.

--- a/_venues/the-den.md
+++ b/_venues/the-den.md
@@ -1,0 +1,4 @@
+---
+title: The Den
+city: Nottingham
+---

--- a/_venues/trent-building.md
+++ b/_venues/trent-building.md
@@ -1,10 +1,10 @@
 ---
 title: Trent Building
-title_short: Trent
 built: 1928
 location:
   lat: 52.936910
   lon: -1.196107
+city: Nottingham
 ---
 
 First opened in 1928, Trent Building has been used by the university mainly for teaching and official events, with conferences being held in both the Great Hall and Senate Chamber. The Trent building is now the home of the Schools of English and Foreign Languages, with offices also for the Vice-Chancellor and other univeristy administration.

--- a/_venues/trent-great-hall.md
+++ b/_venues/trent-great-hall.md
@@ -5,6 +5,7 @@ built: 1928
 location:
   lat: 52.936481
   lon: -1.196394
+city: Nottingham
 ---
 
 First opened in 1928, Trent Great Hall has been used by the university for many official functions. It has been used as a lecture hall, with special lectures having been given by both Mahatma Gandhi and Albert Einstein. However, nowadays, it is mainly used by societies for performances and other events.

--- a/_venues/trent-performing-arts-studio.md
+++ b/_venues/trent-performing-arts-studio.md
@@ -1,10 +1,11 @@
 ---
 title: "Trent, Performing Arts Studio"
-title_short: PAS
+title_short: Performing Arts Studio
 built: 1928
 location:
   lat: 52.937014
   lon: -1.195180
+city: Nottingham
 ---
 
 The Performing Arts Studio, or PAS, is mainly used now by the English departement for both lectures and performance based assessments. The New Theatre used this as it's temporary home at the beginning of the 2012 acadmeic year due to the overrunning of the major redevelopement of the New Theatre building at the time.

--- a/_venues/university-park.md
+++ b/_venues/university-park.md
@@ -1,0 +1,4 @@
+---
+title: University Park
+city: Nottingham
+---

--- a/_venues/zoo.md
+++ b/_venues/zoo.md
@@ -1,0 +1,4 @@
+---
+title: ZOO
+city: Edinburgh
+---


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1690934/26755645/49909a26-4889-11e7-8fb1-7d56bc8abca6.png)

Will close #422

- Add `city` attr to venues, anything other than Nottingham and Edinburgh will be shown in a 'Other' list
- Add `sort` attr to venues to allow pushing NT venues to top
- Small cleanup of `venue_sort` usage.