### PR TITLE
Add quotes from programmes to show pages and format nice

### DIFF
--- a/_shows/11_12/bed.md
+++ b/_shows/11_12/bed.md
@@ -12,6 +12,52 @@ trivia:
   - quote: "A personal highlight was transferring Jim Cartwright's 'Bed' (my first attempt at Directing), to Lakeside's Djanogly Theatre, with a bit of help from Nick Stevenson"
     name: James McAndrew
     submitted: 2015-11-03
+  - quote: |
+      In 2006 I spent an afternoon of school watching the final GCSE drama performance pieces of the year above. Most of them were typical angsty-physical-theatre student drama fare but one was Bed by Jim Cartwright. The weird mix of surrealism, naturalism, comedy, sadness and the fact that teenagers were endeavouring to play characters near 100 years old, has stuck with me long since. So when it came to picking a play to propose for the season, it didn’t take me long to go with this.
+
+      I love how different this play is, especially in its context here at The New Theatre, sandwiched between two Shakespeare's, a Pinter and a Stoppard. I’m hoping that despite its general bizarreness, people young and old will connect with Cartwright’s beautifully rendered characters. Equally I simply hope you enjoy our giant bed.
+
+      Bringing this to the stage has been as challenging as it has rewarding. And for helping me overcome all those challenges I have many people to thank but the biggest thanks of all undoubtedly goes to the wonderful Nick Stevenson, who has astounded me and others with his amazing organisational skills and nack for spotting things I often unknowingly missed. All this considering he is just over two months into the first year of his law degree is astonishing.
+
+      To my wonderful cast I say thank you for so quickly getting to grips with the text and also for putting up with me frequently using film scenes as notes in place of actual direction.
+
+      Favourite Dream: Aliens invaded my primary school and ate all the teachers.
+    name: James McAndrew
+  - quote: |
+      This is my first year at Nottingham and my first show at The New Theatre and so far I have loved every minute of it. I haven’t produced in over a year and it has been great producing here for the first time. I ‘ve met some talented and hilarious people over the last few weeks and it’s been great working with such a dedicated and lovely group of people in the cast. Rehearsals have been a blast and a great break from the ridiculous amount of reading for my degree!
+
+      There’s a few people who deserve a special thanks. I’d first like the thank the cast for their hard work, I’m sure James would agree with me that it would have been twice as stressful if our cast hadn’t have been so energetic and such a laugh to be around.
+
+      I’d also like to thanks James Townend for answering and helping me with my multitude of questions on a regular basis! The set for this play as I’m sure you will agree is pretty special so a big thankyou to Jess Courtney and Grace Lowe for allowing James and I (mainly James) to have our strange ideas brought to life!
+
+      My last thanks of course go to the hilarious and talented director, Mr James McAndrew. I can’t believe this is his first time directing at the New Theatre; he has been an absolute priviledge to work with and get to know. He truly is a walking encyclopedia of film and theatre! He has worked so hard on this play and I’m over the moon I got to produce for him, thanks James!
+
+      Favourtie dream: eating various take-away’s several evenings in a row in a 12x8ft bed…
+    name: Nick Stevenson
+  - quote: "This has been a brilliant production, thanks to everyone involved. I have loved being a part of this theatre, I have been lucky to work with so many lovely and talented people. Favourite dream: My favourite dream is when I fly away from this crazy lot."
+    name: James Townsend
+    submitted: 2011-11-30
+  - quote: "People generally do not like puns, unless they actually thought of them. Thus I shall not attempt to come up with any kind of wit...beyond managing to genuinely fit the word ‘thus’ into my blurb. A wonderfully immense thank you and congratulations to all the cast and crew. You are all superb! Favourite dream: Being in bed...while in bed...with bed...bed"
+    name: Conrad Cohen
+    submitted: 2011-11-30
+  - quote: "Heading...into my first New Theatre production I knew it would be difficult facing...up to the challenge. However, James and Nick stopped me becoming two-faced...and as a result I’ve had a great first experience of the NT! Massive love to the whole cast and crew! Favourite dream: Countless Harry Potter dreams/that memorable day when it rained hummus."
+    name: Nick Jeffrey
+    submitted: 2011-11-30
+  - quote: "As I’m sure you will agree dressing up as an old person and sharing a bed with six other people sounds like a great night out. So merging such a fantasy with a play has created something truly magical. FavouriPte dream: Lady Macbeth."
+    name: Jono Lake
+    submitted: 2011-11-30
+  - quote: "I’ve really enjoyed sleeping with this cast...a laid back, hardworking and talented group of people who I’m sure you’ll agree are great in bed. Favourite dream: I have a favourite type of dream rather than one in particular. I like dreams that you continue the next night without meaning to."
+    name: Amy Brough-Aikin
+    submitted: 2011-11-30
+  - quote: "Thank you so much James, Nick and the cast for creating such a great vibe. I have loved working on such a challenging script. It’s been a learning curve in more ways than one: I expect to master the rules of ninja any day now. Favourite dream: I don’t sleep…"
+    name: Flo Hapgood
+    submitted: 2011-11-30
+  - quote: "Bed is my first play with the New Theatre and I’ve had a cracking time! And I’ve shared it with a great bunch (you’re all winners and all gems!). It’s gonna be pretty lonely in Bed now! Favourite dream: Waking up in Kate Middleton’s wedding dress. Amazing!"
+    name: Suzie Roope
+    submitted: 2011-11-30
+  - quote: "Thanks fellow bedheads, you’ve been a dream!! Great danger lemon and ninja skills. Dear audience, I hope you don’t fall asleep in bed. Sleep tight, and don’t let the bed bugs bite! Favourite dream: Swimming away from the Jurassic Park raptors, or when the peasants of the Victorian village I lived in got murdered by orcs. I escaped in a zeppelin"
+    name: Ellie Cawthorne
+    submitted: 2011-11-30
 
 cast:
   - role: Charles


### PR DESCRIPTION
The nice stuff people write in programmes are a good candidate for adding to the `trivia` section of shows.

![image](https://cloud.githubusercontent.com/assets/1690934/26757353/d19beaac-48b0-11e7-9a18-171e37ca2f59.png)

Buut the expected length of content when that section was designed doesn't quite match the varying lengths in programmes — from short actor notes to multi-paragraph director and producer notes. 

- [x] Add one show's programme notes to base design work on
- [ ] Do design work
- [ ] Add all the programmes notes

We don't have a lot of programmes, we should probably make more of an effort to source them.