### PR TITLE
Lower invalidation period for Smug for Travis cron jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
   - node_modules/
   - lib/
   - vendor/bundle
-  - _smugmug_cache/
   - tmp/
   - ".sass-cache"
 before_install:

--- a/_bin/prep.sh
+++ b/_bin/prep.sh
@@ -14,6 +14,5 @@ fi
 if [[ $RESET = "true" ]]
 then
   rm -rf _site
-  rm -rf _asset_bundler_cache
-  rm -rf _smugmug_cache
+  rm -rf tmp
 fi

--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,8 @@ exclude:
 - bower.json
 - coffeelint.json
 - CONTRIBUTING.md
+- Dockerfile
+- LICENCE
 - Gemfile
 - Gemfile.lock
 - googlee5aee69e17917677.html
@@ -47,6 +49,7 @@ exclude:
 - package.json
 - Rakefile
 - README.md
+- run_dev.sh
 - tmp/
 - Vagrantfile
 - vendor/

--- a/_plugins/hooks.rb
+++ b/_plugins/hooks.rb
@@ -1,3 +1,9 @@
+Jekyll::Hooks.register :site, :after_init do |site|
+  if ENV['TRAVIS_EVENT_TYPE'] == 'cron'
+    Jekyll.logger.info "Build running with cronjob settings"
+  end
+end
+
 Jekyll::Hooks.register :site, :post_read do |site|
   # Initialise the link register
   site.data['link-register'] = LinkList::LinkRegister.new

--- a/_plugins/smugmug.rb
+++ b/_plugins/smugmug.rb
@@ -12,10 +12,6 @@ class Smug
   headers 'Accept' => 'application/json'
   default_timeout 20
 
-  # Cache timings
-  MIN_INVALID_WEEKS = 4
-  MAX_INVALID_WEEKS = 12
-
   def api_key
     ENV['SMUGMUG_API_KEY']
   end
@@ -24,13 +20,30 @@ class Smug
     "_smugmug_cache"
   end
 
+  def min_invalid_time
+    # return the minimum number of seconds that a cached item can stay cached
+    if ENV['TRAVIS_EVENT_TYPE'] == 'cron'
+      days = 1
+    else
+      days = 14
+    end
+    return days * 24 * 60 * 60
+  end
+
+  def max_invalid_time
+    # return the maximum number of seconds that a cached item can stay cached
+    if ENV['TRAVIS_EVENT_TYPE'] == 'cron'
+      days = 6
+    else
+      days = 42
+    end
+    return days * 24 * 60 * 60
+  end
+
   def cache_invalid_time
-    x = MIN_INVALID_WEEKS
-    y = MAX_INVALID_WEEKS - MIN_INVALID_WEEKS
     # Time now, minus x to x+y weeks
-    # We compare the cache file ctime to this
-    #            s  m  h  days
-    ( Time.now - ( 60*60*24*7*x ) - rand( 60*60*24*7*y ) ).to_i
+    # We compare the cache file fetch time to this
+    ( Time.now - min_invalid_time - rand(max_invalid_time - min_invalid_time)).to_i
   end
 
   def cache_filename(id)

--- a/_plugins/smugmug.rb
+++ b/_plugins/smugmug.rb
@@ -17,7 +17,7 @@ class Smug
   end
 
   def cache_dir
-    "_smugmug_cache"
+    "tmp/smugmug"
   end
 
   def min_invalid_time

--- a/_plugins/smugmug.rb
+++ b/_plugins/smugmug.rb
@@ -57,11 +57,12 @@ class Smug
       cache_data = JSON.load(cache_file)
       cache_file.close
 
-      if (not cache_data.key? "FetchTime" or
-        cache_data["FetchTime"] < cache_invalid_time) and api_key and
-        not ENV['SMUGMUG_CACHE_MAINTAIN']
+
+      if (not cache_data.key? "FetchTime" or cache_data["FetchTime"] < cache_invalid_time) and
+        api_key and not ENV['SMUGMUG_CACHE_MAINTAIN']
         # Delete and do over as cache invalid
-        Jekyll.logger.warn("SM cache invalidated:", "Refreshing #{id}")
+        age = (Time.now - cache_data["FetchTime"]).to_i / (3600 * 24)
+        Jekyll.logger.warn("SM cache invalidated:", "Refreshing #{id}, was #{age} days old")
         File.delete(cache_filename(id))
         return nil
       else


### PR DESCRIPTION
Re #884 

Currently we invalidate SM cache 4–16 weeks after first fetch (depending on dice rolls). This was done to keep builds relatively quick.

This change makes Travis cron jobs use different settings (no SM cache will be older than a week). Normal builds should then no longer trip any cache invalidation.