### PR TITLE
Fix and update mapbox gl

### DIFF
--- a/_includes/elements/map.html
+++ b/_includes/elements/map.html
@@ -1,22 +1,27 @@
+<link href='/lib/mapbox-gl.css' rel='stylesheet' />
+
 <div class="map-container" id="map"
      data-lat="{{ include.location.lat }}"
      data-lon="{{ include.location.lon }}"></div>
 
-<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.21.0/mapbox-gl.js'></script>
-<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.21.0/mapbox-gl.css' rel='stylesheet' />
-
 <script>
-    lat = parseFloat("{{ include.location.lat }}");
-    lon = parseFloat("{{ include.location.lon }}");
-    mapboxgl.accessToken = 'pk.eyJ1Ijoid2pkcCIsImEiOiJjaXFwaHU1MmIwMDVoaHhua2hoeDlkYmViIn0.yxRsR2BA6-a4JgvA92eamw';
-    var map = new mapboxgl.Map({
-        container: 'map', // container id
-        attributionControl: false,
-        style: 'mapbox://styles/wjdp/ciqphv4ap0005xim71pqcn8uq', //stylesheet location
-        center: [lon, lat], // starting position
-        zoom: 16 // starting zoom
+    // Script seems to leak between pages because turbolinks
+    // Event can only fire once everything is loaded (mapbox-gl-js library)
+    document.addEventListener("turbolinks:load", function(event) {
+        if (document.querySelector('#map') != null) {
+            lat = parseFloat("{{ include.location.lat }}");
+            lon = parseFloat("{{ include.location.lon }}");
+            mapboxgl.accessToken = 'pk.eyJ1Ijoid2pkcCIsImEiOiJjaXFwaHU1MmIwMDVoaHhua2hoeDlkYmViIn0.yxRsR2BA6-a4JgvA92eamw';
+            var map = new mapboxgl.Map({
+                container: 'map', // container id
+                attributionControl: false,
+                style: 'mapbox://styles/wjdp/ciqphv4ap0005xim71pqcn8uq', //stylesheet location
+                center: [lon, lat], // starting position
+                zoom: 16, // starting zoom
+            });
+            var marker = new mapboxgl.Marker()
+                    .setLngLat([lon, lat])
+                    .addTo(map);
+        }
     });
-    var marker = new mapboxgl.Marker()
-            .setLngLat([lon, lat])
-            .addTo(map);
 </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,7 @@
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,400italic,600|Montserrat:400,700' rel='stylesheet' type='text/css'>
 
   <!-- Local Styles -->
-  <link rel="stylesheet" href="{% static /css/main.css %}">
+  <link rel="stylesheet" href="{% static /css/main.css %}" data-turbolinks-track="reload">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" data-proofer-ignore>
 
   <!-- humans.txt -->
@@ -44,8 +44,12 @@
   {% unless site.skip_opengraph %}{% include opengraph.html %}{% endunless %}
 
   <!-- Scripts -->
-  <script defer type="text/javascript" src="{% static /js/lib.js %}"></script>
+  <script defer type="text/javascript" src="{% static /js/lib.js %}" data-turbolinks-track="reload"></script>
   <script defer type="text/javascript" src="/js/raven.js"></script>
   <script defer type="text/javascript" src="/js/focus-ring.js"></script>
-  <script defer type="text/javascript" src="{% static /js/app.js %}"></script>
+  <script defer type="text/javascript" src="{% static /js/app.js %}" data-turbolinks-track="reload"></script>
+
+  {% for head_extra_line in layout.head_extra %}
+    {{ head_extra_line }}
+  {% endfor %}
 </head>

--- a/_sass/_shame.sass
+++ b/_sass/_shame.sass
@@ -18,3 +18,6 @@
 
     a
       @include no-underline
+
+.mapboxgl-ctrl-logo
+  display: none !important

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,23 +32,36 @@ console.log("")
 // Prevents need for processing lib directory.
 // Prevents both items from presence on sitemap.
 
-var LATE_FILES = [
-  'googlee5aee69e17917677.html',
-  'manifest.json'
+var LATE_FILES_ROOT = [
+    'googlee5aee69e17917677.html',
+    'manifest.json'
 ];
 
+var LATE_FILES_LIB_SINGLES = [
+    'node_modules/mapbox-gl/dist/mapbox-gl.css'
+]
+
 gulp.task('late_files_lib', function() {
+    // Copies contents of lib/ into site
     return gulp.src('lib/**')
                .pipe(gulp.dest('_site/lib'));
 });
 
+gulp.task('late_files_lib_singles', function() {
+    // Copies single files into lib/ in site
+    return gulp.src(LATE_FILES_LIB_SINGLES)
+               .pipe(gulp.dest('_site/lib'));
+});
+
 gulp.task('late_files_images', function() {
+    // Copies contents of images/ into site
     return gulp.src('images/**')
                .pipe(gulp.dest('_site/images'));
 });
 
-gulp.task('late_files', ['late_files_lib', 'late_files_images'], function() {
-    return gulp.src(LATE_FILES)
+gulp.task('late_files', ['late_files_lib', 'late_files_lib_singles', 'late_files_images'], function() {
+    // Depends on the above tasks and copies the root late files
+    return gulp.src(LATE_FILES_ROOT)
              .pipe(gulp.dest('_site'));
 });
 
@@ -108,6 +121,7 @@ var JS_LIBS = [
     'lib/lunr.js/lunr.min.js',
     'lib/picturefill/dist/picturefill.js',
     'lib/moment/moment.js',
+    'node_modules/mapbox-gl/dist/mapbox-gl.js',
     'lib/raven-js/dist/raven.js'
 ]
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "history-project",
   "description": "Historical record of happenings at the New Theatre.",
+  "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "bower": "^1.4.1"
+    "bower": "^1.4.1",
+    "mapbox-gl": "^0.41.0"
   },
   "devDependencies": {
     "coffee-script": "^1.10.0",


### PR DESCRIPTION
Will close #616, will address some issues in #725 but not all.

- We host the mapbox JS and CSS now
- Update to latest version of above
- Fix JS loading issues with above (due to turbolinks)
- Unrelated changes to head.html re turbolinks — the site is forcefully reloaded if CSS or JS assets change (i.e. a build has happened)