### PR TITLE
Add poster to 'The Picture of Dorian Gray', + details, + extra show

### DIFF
--- a/_shows/75_76/nightcap.md
+++ b/_shows/75_76/nightcap.md
@@ -1,12 +1,10 @@
 ---
-title: The Picture of Dorian Gray
+title: "Nightcap: a revue"
 period: Edinburgh
 season: Edinburgh
-playwright: Oscar Wilde
-adapted: Peter Rushton
-season_sort: 400
+season_sort: 410
 venue: Broughton High School
-date_start: 1976-08-23
+date_start: 1976-08-19
 date_end: 1976-09-04
 
 assets:

--- a/_venues/broughton-high-school.md
+++ b/_venues/broughton-high-school.md
@@ -1,0 +1,4 @@
+---
+title: Broughton High School
+city: Edinburgh
+---


### PR DESCRIPTION
- Dorian Grey poster was in the "NNT Archive Upload (10.04.16)" album. Have moved the 'enhanced' version to show assets and linked.
- Updated dates for the dorian grey show and moved to Edinburgh season
- Added Nightcap, also on the same poster
- Added venue stub for the school these two were performed in