### PR TITLE
Fix scroll locking for lightbox and report modals

### DIFF
--- a/_coffee/app/lightbox.coffee
+++ b/_coffee/app/lightbox.coffee
@@ -13,6 +13,7 @@ class LightboxGallery
     i = @getLinkIndex ev.srcElement.parentElement
 
     @lightbox = new Lightbox(@, i)
+    window.currentLightbox = @lightbox
 
   getLinkIndex: (elem) ->
     # Given a link return it's index in the galleryLinks array
@@ -48,7 +49,7 @@ class Lightbox
     window.disable_keyboard_nav = true
 
     # Freeze scrolling
-    @scrollTop = document.body.scrollTop
+    @scrollTop = $(document).scrollTop()
     document.body.style.position = "fixed"
     document.body.style.top = "-#{@scrollTop}px"
 
@@ -154,7 +155,7 @@ class Lightbox
   close: =>
     # Unfreeze scrolling
     document.body.style.position = "static"
-    document.body.scrollTop = @scrollTop
+    $(document).scrollTop(@scrollTop)
 
     # Remove blur
     @blur.classList.remove('lightbox-blur--show')

--- a/_coffee/app/report.coffee
+++ b/_coffee/app/report.coffee
@@ -46,25 +46,43 @@ reportThanks = (url) ->
   template = _.template $('#report-success-template').html()
   $('#report-modal-content').html template('url': url)
 
+frozenScrollTop = null
+
+freezeScrolling = () ->
+  # Freeze scrolling
+  frozenScrollTop = $(document).scrollTop()
+  document.body.style.position = "fixed"
+  document.body.style.top = "-#{frozenScrollTop}px"
+
+unfreezeScrolling = () ->
+  # Unfreeze scrolling
+  document.body.style.position = "static"
+  $(document).scrollTop(frozenScrollTop)
+
 document.addEventListener 'turbolinks:load', ->
   $('#report-this-page').click (e) ->
     e.preventDefault()
+    freezeScrolling()
     $('#report').addClass 'report-show'
   $('[data-report-close]').click (e) ->
     e.preventDefault()
+    unfreezeScrolling()
     $('#report').removeClass 'report-show'
     $('#improve').removeClass 'report-show'
 
   $('#improve-this-page').click (e) ->
     if localStorage.debug_mode isnt "yes"
       e.preventDefault()
+      freezeScrolling()
       $('#improve').addClass 'report-show'
   $('[data-improve-close]').click (e) ->
     e.preventDefault()
+    unfreezeScrolling()
     $('#improve').removeClass 'report-show'
 
   $('[data-report-this-page]').click (e) ->
     e.preventDefault()
+    freezeScrolling()
     $('#improve').removeClass 'report-show'
     $('#report').addClass 'report-show'
 


### PR DESCRIPTION
- Will close #915: Fix broken scroll locking on lightbox where it's just jump you to the top of the page on modal exit.

- Will close #640: Add that fixed scroll locking to report modals.
