### PR TITLE
Implement (better) awards

### DIFF
--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -93,7 +93,9 @@ body_class: layout-person header-nobr content-nobr
 
         {% if person.award %}
         <dt><i class="fa fa-fw fa-trophy"></i>Award</dt>
-        <dd>{{ person.award }}</dd>
+          {% for award in person.award %}
+            <dd><strong>{{ award.org }}, {{ award.year }}: </strong>{{ award.title }} {% if award.show %}(<i>{{ award.show }}</i>){% endif %}</dd>
+          {% endfor %}
         {% endif %}
 
         {% if person.committees %}

--- a/_people/ali_blackwell.md
+++ b/_people/ali_blackwell.md
@@ -6,7 +6,10 @@ headshot: xR63swn
 course:
   - English Studies
 graduated: 2008
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2008 
 careers:
   - Web Designer
   - Technology Consultant

--- a/_people/andy_mcnamee.md
+++ b/_people/andy_mcnamee.md
@@ -5,7 +5,10 @@ headshot: kD9JFM3
 course:
   - Film and Television Studies
 graduated: 2010
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2010
 submitted: false
 careers:
   - Freelance Director

--- a/_people/ben_hollands.md
+++ b/_people/ben_hollands.md
@@ -7,7 +7,10 @@ course:
   - English
 graduated: 2015
 contact_allowed: true
-award: Fellowship
+award:
+  - title: Fellowship
+    org: NNT
+    year: 2015
 links:
  - type: LinkedIn
    username: ben-hollands-0ab589122

--- a/_people/charlie_brafman.md
+++ b/_people/charlie_brafman.md
@@ -2,7 +2,10 @@
 title: Charlie Brafman
 gender: male
 graduated: 2008
-award: Fellowship
+award:
+  - title: Fellowship
+    org: NNT
+    year: 2008
 links:
   - type: Twitter
     username: chazbobb

--- a/_people/chris_trueman.md
+++ b/_people/chris_trueman.md
@@ -3,6 +3,9 @@ title: Chris Trueman
 headshot: HdcsxkW
 gender: male
 graduated: 2017
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2017
 submitted: false
 ---

--- a/_people/daniel_oconnor.md
+++ b/_people/daniel_oconnor.md
@@ -3,7 +3,10 @@ title: "Daniel O'Connor"
 gender: male
 headshot: QffpFWG
 graduated: 2015
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2015
 submitted: false
 links:
  - type: LinkedIn

--- a/_people/david_trennery.md
+++ b/_people/david_trennery.md
@@ -11,5 +11,8 @@ careers:
 links:
   - type: Personal Website
     href: "http://www.thoughtfulprimate.co.uk"
-award: Union Prize
+award: 
+  - title: Union Prize
+    org: UoNSU
+    year: 1996 
 ---

--- a/_people/douggie_mcmeekin.md
+++ b/_people/douggie_mcmeekin.md
@@ -4,6 +4,11 @@ headshot: TXqLQv2
 gender: male
 graduated: 2010
 submitted: false
+award: 
+  - title: Judges' Award for Acting
+    org: NSDF
+    year: 2011
+    show: Orphans
 course:
   - Physics
 

--- a/_people/eden_phillips_harrington.md
+++ b/_people/eden_phillips_harrington.md
@@ -3,7 +3,10 @@ title: Eden Phillips Harrington
 headshot: d4TkLKg
 gender: female
 graduated: 2016
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2016
 submitted: false
 ---
 

--- a/_people/eloise_hyde.md
+++ b/_people/eloise_hyde.md
@@ -1,0 +1,10 @@
+---
+title: Eloise Hyde
+gender: female
+submitted: false
+award:
+  - title: Kathleen Herron Individual Commendation
+    org: NSDF
+    year: 2013
+    show: The Memory of Water
+---

--- a/_people/emma-louise_amanshia.md
+++ b/_people/emma-louise_amanshia.md
@@ -2,7 +2,10 @@
 title: "Emma-Louise Amanshia"
 gender: female
 graduated: 2013
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2013
 submitted: false
 headshot: 9zKK6p4
 ---

--- a/_people/gus_miller.md
+++ b/_people/gus_miller.md
@@ -3,4 +3,9 @@ title: Gus Miller
 gender: male
 submitted: false
 graduated: 2012
+award: 
+  - title: Outstanding Production Design
+    org: NSDF
+    year: 2011
+    show: After the End
 ---

--- a/_people/jake_leonard.md
+++ b/_people/jake_leonard.md
@@ -3,7 +3,10 @@ title: Jake Leonard
 gender: male
 headshot: TJT7nNV
 graduated: 2015
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2015
 submitted: false
 links:
  - type: LinkedIn

--- a/_people/jake_leonard.md
+++ b/_people/jake_leonard.md
@@ -7,6 +7,10 @@ award:
   - title: Fellowship
     org: NNT
     year: 2015
+  - title: Judges' Award for Best Supporting Actor
+    org: NSDF
+    year: 2013
+    show: Jerusalem
 submitted: false
 links:
  - type: LinkedIn

--- a/_people/james_bentley.md
+++ b/_people/james_bentley.md
@@ -3,7 +3,10 @@ title: James Bentley
 headshot: zSShTZm
 gender: male
 graduated: 2015
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2015
 submitted: false
 course:
   - Management

--- a/_people/james_herbert.md
+++ b/_people/james_herbert.md
@@ -2,7 +2,10 @@
 title: James Herbert
 gender: male
 graduated: 2009
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2009
 submitted: false
 ---
 

--- a/_people/james_mcandrew.md
+++ b/_people/james_mcandrew.md
@@ -6,7 +6,10 @@ headshot: 5GmrwHr
 course:
   - Film and Television
 graduated: 2014
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2014 
 links:
   - type: Portfolio
     href: "https://app.hiive.co.uk/profile/26f6b95b-9837-4370-9813-accd981ae2e6/#/"

--- a/_people/jess_courtney.md
+++ b/_people/jess_courtney.md
@@ -5,7 +5,10 @@ headshot: 6G8LRvn
 course:
   - Archaeology and Art History
 graduated: 2013
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2013
 submitted: false
 careers:
   - Events Assistant

--- a/_people/jess_courtney.md
+++ b/_people/jess_courtney.md
@@ -9,6 +9,10 @@ award:
   - title: Fellowship
     org: NNT
     year: 2013
+  - title: Best Production Design
+    org: NSDF
+    year: 2013
+    show: Jerusalem
 submitted: false
 careers:
   - Events Assistant

--- a/_people/joanne_blunt.md
+++ b/_people/joanne_blunt.md
@@ -3,7 +3,10 @@ title: Joanne Blunt
 headshot: WGkCB8J
 gender: female
 graduated: 2017
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2017
 submitted: false
 course:
  - Physics with German

--- a/_people/jonny_khan.md
+++ b/_people/jonny_khan.md
@@ -4,6 +4,11 @@ gender: male
 submitted: false
 course:
   - Economics
+award:
+  - title: Commendation for Acting
+    org: NSDF
+    year: 2018
+    show: Pomona
 
 
 links:

--- a/_people/joseph_heil.md
+++ b/_people/joseph_heil.md
@@ -2,7 +2,10 @@
 title: Joseph Heil
 gender: male
 graduated: 2015
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2015
 course: Materials Engineering and Design, PhD
 submitted: 17/11/2016
 headshot: fX9MPP9

--- a/_people/laura_gallop.md
+++ b/_people/laura_gallop.md
@@ -1,0 +1,10 @@
+---
+title: Laura Gallop
+gender: female
+submitted: false
+award:
+  - title: Spotlight Award for Acting
+    org: NSDF
+    year: 2013
+    show: Mercury Fur
+---

--- a/_people/lawrence_bolton.md
+++ b/_people/lawrence_bolton.md
@@ -2,7 +2,10 @@
 title: Lawrence Bolton
 gender: male
 graduated: 2012
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2012
 submitted: false
 headshot: HnWzdxd
 course:

--- a/_people/lizzie_bourne.md
+++ b/_people/lizzie_bourne.md
@@ -2,7 +2,10 @@
 title: Lizzie Bourne
 gender: female
 graduated: 2010
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2010
 submitted: false
 headshot: 8qDHpz8
 course:

--- a/_people/lizzie_bourne.md
+++ b/_people/lizzie_bourne.md
@@ -6,6 +6,10 @@ award:
   - title: Fellowship
     org: NNT
     year: 2010
+  - title: Spotlight Award for Most Promising Actress
+    org: NSDF
+    year: 2011
+    show: Amadeus
 submitted: false
 headshot: 8qDHpz8
 course:
@@ -16,3 +20,4 @@ links:
     href: "https://www.castingcallpro.com/uk/actor/profile/lizzie-bourne"
 ---
 
+Following graduation from the University of Nottingham, Lizzie studied at the University of Edinburgh. 

--- a/_people/lucy_bromilow.md
+++ b/_people/lucy_bromilow.md
@@ -1,16 +1,11 @@
 ---
-title: Meg Salter
+title: Lucy Bromilow
 gender: female
-graduated: 2012
 award: 
-  - title: Fellowship
-    org: NNT
-    year: 2012
   - title: Judges' Award for Acting
     org: NSDF
     year: 2011
     show: This Wide Night
 submitted: false
-headshot: 4RbXrZh
 ---
 

--- a/_people/lyle_fulton.md
+++ b/_people/lyle_fulton.md
@@ -2,7 +2,10 @@
 title: Lyle Fulton
 gender: male
 graduated: 2014
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2014
 submitted: false
 headshot: 8PpT7WV
 

--- a/_people/matt_leventhall.md
+++ b/_people/matt_leventhall.md
@@ -4,7 +4,10 @@ gender: male
 headshot: rzcdPpN
 course: Philosophy
 graduated: 2009
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2009
 submitted: false
 careers: Lighting Designer
 links:

--- a/_people/matt_wilks.md
+++ b/_people/matt_wilks.md
@@ -5,7 +5,10 @@ gender: male
 course:
   - BA English
 graduated: 2013
-award: Commendation
+award: 
+  - title: Commendation
+    org: NNT
+    year: 2013
 links:
   - type: Portfolio
     href: "http://www.2magpiestheatre.co.uk/"

--- a/_people/max_miller.md
+++ b/_people/max_miller.md
@@ -3,7 +3,10 @@ title: Max Miller
 headshot: FXmhrbS
 gender: male
 graduated: 2017
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2017
 submitted: false
 course:
  - Geography

--- a/_people/meg_salter.md
+++ b/_people/meg_salter.md
@@ -2,7 +2,10 @@
 title: Meg Salter
 gender: female
 graduated: 2012
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2012
 submitted: false
 headshot: 4RbXrZh
 ---

--- a/_people/niamh_caines.md
+++ b/_people/niamh_caines.md
@@ -2,7 +2,10 @@
 title: Niamh Caines
 headshot: KQ58fCc
 gender: female
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2017
 graduated: 2017
 submitted: false
 course:

--- a/_people/nick_barker.md
+++ b/_people/nick_barker.md
@@ -3,7 +3,10 @@ title: Nick Barker
 gender: male
 headshot: 5JqcZJx
 graduated: 2014
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2014 
 submitted: false
 links:
  - type: LinkedIn

--- a/_people/nick_gill.md
+++ b/_people/nick_gill.md
@@ -3,7 +3,10 @@ title: Nick Gill
 headshot: 3xMcmD4
 gender: male
 graduated: 2016
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2016
 submitted: 04/01/2017
 contact_allowed: true
 course:

--- a/_people/nick_stevenson.md
+++ b/_people/nick_stevenson.md
@@ -5,7 +5,10 @@ gender: male
 headshot: vRML2VN
 course: Law
 graduated: 2014
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2014 
 careers:
   - Producer
 links:

--- a/_people/ollie_shortt.md
+++ b/_people/ollie_shortt.md
@@ -3,7 +3,10 @@ title: Ollie Shortt
 headshot: SNjz5gq
 gender: male
 graduated: 2016
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2016
 submitted: false
 course:
   - Law

--- a/_people/peter_bradley.md
+++ b/_people/peter_bradley.md
@@ -1,0 +1,10 @@
+---
+title: Peter Bradley
+gender: male
+submitted: false
+award:
+  - title: Buzz Goodbody Award for Best Student Director
+    org: NSDF
+    year: 2013
+    show: Jerusalem
+---

--- a/_people/philip_geller.md
+++ b/_people/philip_geller.md
@@ -10,6 +10,10 @@ award:
   - title: Fellowship
     org: NNT
     year: 2011
+  - title: Outstanding Production Design
+    org: NSDF
+    year: 2011
+    show: After the End
 careers:
   - Teaching
   - Production Manager

--- a/_people/philip_geller.md
+++ b/_people/philip_geller.md
@@ -6,7 +6,10 @@ headshot: r7mQ7H6
 course:
   - Mechanical Engineering
 graduated: 2011
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2011
 careers:
   - Teaching
   - Production Manager

--- a/_people/rebecca_catlin.md
+++ b/_people/rebecca_catlin.md
@@ -5,7 +5,10 @@ course:
   - English Language and Literature
   - Theatre Research
 graduated: 2011
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2011
 submitted: false
 careers: 
   - English Teacher

--- a/_people/rosanna_stoker.md
+++ b/_people/rosanna_stoker.md
@@ -1,0 +1,10 @@
+---
+title: Rosanna Stoker
+gender: female
+submitted: false
+award:
+  - title: Spotlight Award for Acting
+    org: NSDF
+    year: 2013
+    show: The Memory of Water
+---

--- a/_people/sam_hayward.md
+++ b/_people/sam_hayward.md
@@ -4,7 +4,10 @@ gender: male
 course:
   - Philosophy and Theology
 graduated: 2013
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2013
 submitted: false
 headshot: wZMFgnJ
 

--- a/_people/tim_watkins.md
+++ b/_people/tim_watkins.md
@@ -2,7 +2,10 @@
 title: Tim Watkins
 gender: male
 graduated: 2011
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2011
 submitted: false
 ---
 

--- a/_people/tom_selves.md
+++ b/_people/tom_selves.md
@@ -5,7 +5,10 @@ headshot: dKqC9hr
 course:
   - LLB Law with European Law
 graduated: 2016
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2016
 submitted: false
 links:
  - type: LinkedIn

--- a/_people/will_pimblett.md
+++ b/_people/will_pimblett.md
@@ -7,7 +7,10 @@ course:
   - Mechanical Engineering
   - Computer Science
 graduated: 2014
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2014 
 contact_allowed: true
 careers:
   - Software Development

--- a/_people/will_vickers.md
+++ b/_people/will_vickers.md
@@ -2,7 +2,10 @@
 title: Will Vickers
 gender: male
 graduated: 2010
-award: Fellowship
+award: 
+  - title: Fellowship
+    org: NNT
+    year: 2010
 submitted: false
 ---
 

--- a/_shows/10_11/after_the_end.md
+++ b/_shows/10_11/after_the_end.md
@@ -35,6 +35,14 @@ crew:
   - role: Make-Up
     name: Emily Heaton
 
+links:
+  - type: Review
+    snapshot: GZV1F
+    publisher: "Noises Off / The University of Nottingham"
+    title: "Student run theatre steals the show"
+    date: 2011-05-12
+    quote: "This production was crafted with great detail, precision and acute awareness of pace, but at the same time portrayed moments of immense emotional drama."
+
 published: true
 
 prod_shots: 4DbWrF

--- a/_shows/10_11/after_the_end.md
+++ b/_shows/10_11/after_the_end.md
@@ -37,6 +37,7 @@ crew:
 
 links:
   - type: Review
+    href: https://archive.fo/GZV1F
     snapshot: GZV1F
     publisher: "Noises Off / The University of Nottingham"
     title: "Student run theatre steals the show"

--- a/_shows/10_11/bluebird.md
+++ b/_shows/10_11/bluebird.md
@@ -40,6 +40,14 @@ assets:
 
 published: true
 
+links:
+  - type: Review
+    snapshot: GZV1F
+    publisher: "Noises Off / The University of Nottingham"
+    title: "Student run theatre steals the show"
+    date: 2011-05-12
+    quote: "As a pure piece of story-telling it is unparalleled, and the performances from the entire ensemble will tug at your heart strings, leave you with a tear in your eye and, in a bizarre juxtaposition, your heart lifted."
+
 prod_shots: hK3T2p
 ---
 

--- a/_shows/10_11/bluebird.md
+++ b/_shows/10_11/bluebird.md
@@ -42,6 +42,7 @@ published: true
 
 links:
   - type: Review
+    href: https://archive.fo/GZV1F
     snapshot: GZV1F
     publisher: "Noises Off / The University of Nottingham"
     title: "Student run theatre steals the show"

--- a/_shows/10_11/orphans.md
+++ b/_shows/10_11/orphans.md
@@ -36,6 +36,14 @@ assets:
   - type: poster
     image: Dc3nnVZ
 
+links:
+  - type: Review
+    snapshot: GZV1F
+    publisher: "The Sunday Times / The University of Nottingham"
+    title: "Student run theatre steals the show"
+    date: 2011-05-12
+    quote: "The true ruling tone of the festival was set by Nottingham University's revival of Oprhans."
+
 published: true
 
 prod_shots: 7hRj7P

--- a/_shows/10_11/orphans.md
+++ b/_shows/10_11/orphans.md
@@ -38,6 +38,7 @@ assets:
 
 links:
   - type: Review
+    href: https://archive.fo/GZV1F
     snapshot: GZV1F
     publisher: "The Sunday Times / The University of Nottingham"
     title: "Student run theatre steals the show"

--- a/_shows/10_11/this_wide_night.md
+++ b/_shows/10_11/this_wide_night.md
@@ -27,6 +27,14 @@ assets:
     video: Bc5bGv5
     title: Backstage At
 
+links:
+  - type: Review
+    snapshot: GZV1F
+    publisher: "The Stage / The University of Nottingham"
+    title: "Student run theatre steals the show"
+    date: 2011-05-12
+    quote: "Salter and Bromilow have the measure of their characters and they play off each other superbly. Their reactions are exact, their emotions believable, their despair is heartbreaking."
+
 published: true
 
 prod_shots: d5RBFx

--- a/_shows/10_11/this_wide_night.md
+++ b/_shows/10_11/this_wide_night.md
@@ -29,6 +29,7 @@ assets:
 
 links:
   - type: Review
+    href: https://archive.fo/GZV1F
     snapshot: GZV1F
     publisher: "The Stage / The University of Nottingham"
     title: "Student run theatre steals the show"

--- a/_shows/12_13/jerusalem.md
+++ b/_shows/12_13/jerusalem.md
@@ -8,6 +8,10 @@ venue: New Theatre
 date_start: 2012-12-05
 date_end: 2012-12-08
 
+award:
+  - title: Best Ensemble
+    org: NSDF
+    year: 2013
 
 tour:
 - venue: NSDF 2013


### PR DESCRIPTION
Render more detailed information about awards. Now shows: Organisation who gave the award; year; show award was given for (where relevant).

To Do:
[ ] - Not show the 'awards' and 'committees' header on the person page if none is set. (The logic exists but is not working - confuse!)
[ ] - Add Boat Party Awards (see #601) 
[ ] - Display show awards on the show page (eg, Best In House Show, etc.)