### PR TITLE
Enforce incomplete cast/crew boxes

### DIFF
--- a/_data/defs/show.yaml
+++ b/_data/defs/show.yaml
@@ -165,10 +165,28 @@
   short: Cast members
   description: "Uses the [person list](/docs/person_list/) format."
 
+- attr: cast_incomplete 
+  type: boolean 
+  short: Incomplete Cast 
+  description: Enforces the 'Missing Details' box to appear regardless of cast size.
+
+- attr: cast_note 
+  type: string 
+  description: Replaces the text in the default 'Missing Details' box with a custom string (does not replace the call to action). Only appears when `cast_incomplete` is set to `true`, as there is no minimum cast size.
+
 - attr: crew
   type: array
   short: Crew members
   description: "Uses the [person list](/docs/person_list/) format."
+
+- attr: crew_incomplete 
+  type: boolean 
+  short: Incomplete Crew 
+  description: Enforces the 'Missing Details' box to appear regardless of crew size (automatically appears when there are fewer than 5 crew).
+
+- attr: crew_note 
+  type: string 
+  description: Replaces the text in the default 'Missing Details' box with a custom string (does not replace the call to action). 
 
 - attr: prod_shots
   type: string

--- a/_includes/boxes/show_cast_short.html
+++ b/_includes/boxes/show_cast_short.html
@@ -1,0 +1,4 @@
+<div class="box-warning">
+  <i class="fa fa-exclamation-triangle"></i>
+  <p><strong>Incomplete Cast List</strong> {% if include.cast_note %}{{ include.cast_note }}{% else %}The cast list for this show is missing some people or details.{% endif %} {% include boxes/phrase_if_you_can_help.html %}</p>
+</div>

--- a/_includes/boxes/show_crew_short.html
+++ b/_includes/boxes/show_crew_short.html
@@ -1,4 +1,4 @@
 <div class="box-warning">
   <i class="fa fa-exclamation-triangle"></i>
-  <p><strong>Short Crew List</strong> The crew list for this show looks a little short. {% include boxes/phrase_if_you_can_help.html %}</p>
+  <p><strong>Incomplete Crew List</strong> {% if include.crew_note %}{{ include.crew_note }}{% else %}The crew list for this show looks a little short.{% endif %} {% include boxes/phrase_if_you_can_help.html %}</p>
 </div>

--- a/_layouts/show.html
+++ b/_layouts/show.html
@@ -240,6 +240,11 @@ body_class: section-archives layout-show
     <section class="show-cast debug-container">
       <div class="debug-abs-top-left" data-debug-toggle title="Number of cast">{{ show.cast.size }}</div>
       {% unless show.ignore_missing and show.cast.size == null %}<h3>Cast</h3>{% endunless %}
+      {% if show.cast_incomplete == true %} 
+        {% unless show.ignore_missing %} 
+          {% include boxes/show_cast_short.html cast_note=show.cast_note %}
+        {% endunless %}
+      {% endif %}
       {% if show.cast == null %}
         {% unless show.ignore_missing %}
           {% include boxes/show_cast_missing.html %}
@@ -251,9 +256,9 @@ body_class: section-archives layout-show
     <section class="show-crew debug-container">
       <div class="debug-abs-top-left" data-debug-toggle title="Nunber of crew">{{ show.crew.size }}</div>
       {% unless show.ignore_missing and show.crew.size == null %}<h3>Crew</h3>{% endunless %}
-      {% if show.crew.size < site.show_low_crew %}
+      {% if show.crew.size < site.show_low_crew or show.crew_incomplete == true %}
         {% unless show.ignore_missing %}
-          {% include boxes/show_crew_short.html %}
+          {% include boxes/show_crew_short.html crew_note=show.crew_note %}        
         {% endunless %}
       {% endif %}
       {% if show.crew == null %}

--- a/_shows/10_11/chasing_dragons.md
+++ b/_shows/10_11/chasing_dragons.md
@@ -28,6 +28,8 @@ crew:
   - role: Director
     name: Adam H. Wells
 
+crew_note: "We're missing at least a producer for this show."
+
 assets:
   - type: poster
     image: DF9fsRr

--- a/_shows/11_12/be_my_baby.md
+++ b/_shows/11_12/be_my_baby.md
@@ -32,6 +32,9 @@ crew:
   - name: Emma-Louise Amanshia
   - name: Emma McDonald
 
+crew_incomplete: true 
+crew_note: "We think we have most of the crew, but aren't sure of their roles."
+
 assets:
   - type: poster
     image: HNpn7GJ


### PR DESCRIPTION
- Enforce the boxes
  - Rephrased 'short' to 'incomplete' as we sometimes know all the names but not all the roles.
- Add custom message
  - Message will only appear when `x_incomplete` is `true` except in the case where the crew list is already short.
- Documentation
- Initial use cases

To close #90 
