### PR TITLE
Update ignore_missing in show.rb

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,6 +78,13 @@ year_end: 2018
 # Estimation conf
 estimate_recency_limit: 2 # How many years to wait until guessing someone has left
 
+# Which seasons to prevent generation of 'missing content' boxes in 
+ignore_missing_in_seasons:
+  - 'External'
+  - 'Postgrads'
+  - 'STUFF'
+  - 'StuFF'
+
 collections:
   content:
     output: true

--- a/_data/defs/show.yaml
+++ b/_data/defs/show.yaml
@@ -81,7 +81,7 @@
 - attr: ignore_missing
   type: boolean
   short: Suppresses missing detail warnings
-  description: "Is `true` when season matches External, Postgrads or STUFF."
+  description: "Is `true` when season matches External, Postgrads or STUFF (as per list in `_config.yml`)."
   generated: true
 
 - attr: year

--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -129,6 +129,7 @@ module Jekyll
       'External',
       'Postgrads',
       'STUFF',
+      'StuFF',
     ]
 
     def ignore_missing(show)

--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -125,16 +125,9 @@ module Jekyll
       # "shows/#{show.data['year']}/#{show.basename_without_ext}.html"
     end
 
-    IGNORE_MISSING_IN_SEASONS = [
-      'External',
-      'Postgrads',
-      'STUFF',
-      'StuFF',
-    ]
-
-    def ignore_missing(show)
+    def ignore_missing(show, seasons)
       # Should we ignore most errors on this show record?
-      IGNORE_MISSING_IN_SEASONS.include? show.data['season']
+      seasons.include? show.data['season']
     end
 
     def generate_show_pls(show, key)
@@ -214,7 +207,7 @@ module Jekyll
       end
 
       # Set ignore_missing if not already
-      show.data["ignore_missing"] ||= ignore_missing(show)
+      show.data["ignore_missing"] ||= ignore_missing(show, @site.config["ignore_missing_in_seasons"])
     end
 
     def sort_shows(shows)


### PR DESCRIPTION
Makes setting `crew_incomplete: false` or `ignore_missing: true` on more recent StuFF shows redundant.
Move the list of seasons to ignore_missing on to _config.yml