### PR TITLE
Add 'improvised' and 'devised' to the show list by-line

### DIFF
--- a/_data/defs/show.yaml
+++ b/_data/defs/show.yaml
@@ -14,6 +14,10 @@
   short: Used if play was devised
   description: "Either `true` for generic output or a descriptor. Example descriptor: `Cast and Crew` will output “Devised by Cast and Crew”. Omit if using playwright."
 
+- attr: improvised
+  short: Used if a play was (fully) improvised. 
+  description: "Omit if false. Primarily used for fully improvised shows, rather than scripted shows with improvised elements."
+
 - attr: adaptor
   type: string
   short: Full name of adaptor
@@ -27,7 +31,7 @@
 - attr: playwright_type
   type: string
   short: Playwright type
-  description: Either `playwright`, `devised`, `various`, or `unknown`.
+  description: Either `playwright`, `devised`, `improvised`, `various`, or `unknown`.
   generated: true
 
 - attr: playwright_formatted

--- a/_includes/show_list.html
+++ b/_includes/show_list.html
@@ -18,9 +18,13 @@
 
     <span class="show-list-title">{{ show.title | escape_once }}</span>
 
-    {% if show.playwright %}
-    <span class="show-list-playwright show-list-playwright-{{ show.playwright.playwright_type }}">
-      {% if show.student_written %}
+    {% if show.playwright_type != 'unknown' %}
+    <span class="show-list-playwright show-list-playwright-{{ show.playwright_type }}">
+      {% if show.playwright_type == 'devised' %}
+        <i class="fa fa-group show-devised" title="{{ show.playwright_formatted_long }}"></i>
+      {% elsif show.playwright_type == 'improvised' %}
+        <i class="fa fa-comments-o show-improvised" title="Improvised"></i>
+      {% elsif show.student_written %}
         <i class="fa fa-pencil show-student-written" title="Student Written"></i>
       {% endif %}
       {{ show.playwright_formatted_long | escape_once }}

--- a/_layouts/show.html
+++ b/_layouts/show.html
@@ -57,6 +57,8 @@ body_class: section-archives layout-show
             <i class="meta-icon fa fa-pencil" title="Student Written"></i>
           {% elsif show.playwright_type == "devised" %}
             <i class="meta-icon fa fa-group"></i>
+          {% elsif show.playwright_type == 'improvised' %}
+            <i class="meta-icon fa fa-comments-o"></i>
           {% else %}
             <i class="meta-icon fa fa-book"></i>
           {% endif %}

--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -30,6 +30,11 @@ module Jekyll
         else
           ["devised", nil, "Devised by #{ show.data["devised"] }"]
         end
+      elsif show.data.key?("improvised")
+        # Is an improv show 
+        if show.data["improvised"] == true
+          ["improvised", nil, "Improvised"]
+        end 
       else
         # Is
         ["unknown", nil, "Playwright Unknown"]

--- a/_sass/components/_show-list.sass
+++ b/_sass/components/_show-list.sass
@@ -54,6 +54,6 @@
     .show-list-date
 
 
-.show-student-written
+.show-student-written, .show-devised, .show-improvised 
   color: $color-grey
 

--- a/_shows/07_08/the_cranberry_chamber.md
+++ b/_shows/07_08/the_cranberry_chamber.md
@@ -8,6 +8,7 @@ season_sort: 220
 venue: New Theatre
 date_start: 2008-02-13
 date_end: 2008-02-16
+improvised: true
 
 cast:
 - role: Narrator

--- a/_shows/10_11/a_day_in_the_life.md
+++ b/_shows/10_11/a_day_in_the_life.md
@@ -5,6 +5,7 @@ company: The Red Herrings
 season: External
 season_sort: 140
 venue: New Theatre
+improvised: true
 
 crew:
   - role: Director

--- a/_shows/12_13/bright_ideas.md
+++ b/_shows/12_13/bright_ideas.md
@@ -2,6 +2,7 @@
 title: "Bright Ideas"
 playwright:
 season: Fundraiser
+student_written: true 
 season_sort: 283
 period: Spring
 venue: New Theatre

--- a/_shows/12_13/the_red_herrings_present_best_book.md
+++ b/_shows/12_13/the_red_herrings_present_best_book.md
@@ -7,6 +7,7 @@ season_sort: 190
 date_start: 2013-02-13
 date_end: 2013-02-16
 venue: New Theatre
+improvised: true
 
 crew:
   - role: Producer

--- a/_shows/13_14/bantermime.md
+++ b/_shows/13_14/bantermime.md
@@ -8,6 +8,7 @@ season_sort: 170
 date_start: 2014-02-12
 date_end: 2014-02-15
 venue: New Theatre
+improvised: true
 
 assets:
   - type: poster

--- a/_shows/14_15/an_introduction_to_improvised_storytelling.md
+++ b/_shows/14_15/an_introduction_to_improvised_storytelling.md
@@ -6,6 +6,7 @@ season_sort: 490
 date_start: 2015-06-18
 date_end: 2015-06-19
 venue: New Theatre Studio B
+improvised: true
 
 assets:
   - type: poster

--- a/_shows/14_15/emily_and_ben_in_a_likely_story.md
+++ b/_shows/14_15/emily_and_ben_in_a_likely_story.md
@@ -6,6 +6,7 @@ season_sort: 220
 date_start: 2015-02-09
 date_end: 2015-02-10
 venue: New Theatre
+improvised: true
 
 cast:
   - name: Ben Hollands

--- a/_shows/14_15/emily_and_ben_in_a_likely_story_stuff.md
+++ b/_shows/14_15/emily_and_ben_in_a_likely_story_stuff.md
@@ -5,6 +5,7 @@ season: "StuFF"
 season_sort: 460
 date_start: 2015-06-17
 venue: New Theatre Studio A
+improvised: true
 
 cast:
   - name: Ben Hollands

--- a/_shows/14_15/the_red_herrings_present_small_world.md
+++ b/_shows/14_15/the_red_herrings_present_small_world.md
@@ -7,6 +7,7 @@ season_sort: 230
 date_start: 2015-02-11
 date_end: 2015-02-14
 venue: New Theatre
+improvised: true
 
 assets:
   - type: poster

--- a/_shows/14_15/uon_improv_show.md
+++ b/_shows/14_15/uon_improv_show.md
@@ -5,6 +5,7 @@ season: "StuFF"
 season_sort: 530
 date_start: 2015-06-19
 venue: New Theatre
+improvised: true
 
 assets:
   - type: poster

--- a/_shows/15_16/when_the_lights_come_up.md
+++ b/_shows/15_16/when_the_lights_come_up.md
@@ -7,6 +7,7 @@ season_sort: 230
 date_start: 2016-02-10
 date_end: 2016-02-13
 venue: New Theatre
+improvised: true
 
 crew_incomplete: false
 

--- a/_shows/15_16/when_the_lights_come_up_stuff.md
+++ b/_shows/15_16/when_the_lights_come_up_stuff.md
@@ -6,6 +6,7 @@ season: StuFF
 season_sort: 460
 date_start: 2016-06-14
 venue: New Theatre
+improvised: true
 
 crew_incomplete: false
 

--- a/_shows/16_17/improvabunga.md
+++ b/_shows/16_17/improvabunga.md
@@ -6,6 +6,7 @@ season: StuFF
 season_sort: 480
 date_start: 2017-06-20
 venue: New Theatre Studio A
+improvised: true 
 
 crew_incomplete: false
 

--- a/_shows/16_17/one_word_story_land.md
+++ b/_shows/16_17/one_word_story_land.md
@@ -7,6 +7,7 @@ season_sort: 210
 date_start: 2017-01-29
 date_end: 2017-02-01
 venue: New Theatre
+improvised: true 
 
 crew_incomplete: false
 

--- a/_shows/17_18/and_another_thing.md
+++ b/_shows/17_18/and_another_thing.md
@@ -7,6 +7,7 @@ season_sort: 170
 date_start: 2018-01-29
 date_end: 2018-02-02
 venue: New Theatre
+improvised: true
 
 crew_incomplete: false
 

--- a/_shows/17_18/and_another_thing_stuff.md
+++ b/_shows/17_18/and_another_thing_stuff.md
@@ -6,6 +6,7 @@ period: Spring
 venue: New Theatre Studio A
 date_start: 2018-06-16
 company: UoN Improv
+improvised: true
 
 crew_incomplete: false
 

--- a/_shows/17_18/ben_and_ian.md
+++ b/_shows/17_18/ben_and_ian.md
@@ -5,6 +5,7 @@ season_sort: 420
 period: Spring
 venue: New Theatre Studio A
 date_start: 2018-06-16
+improvised: true
 
 crew_incomplete: false
   

--- a/_shows/17_18/puck.md
+++ b/_shows/17_18/puck.md
@@ -6,6 +6,7 @@ season_sort: 500
 period: Spring
 venue: New Theatre
 date_start: 2018-06-17
+student_written: true 
 
 crew_incomplete: false
 

--- a/_shows/17_18/rising_tides.md
+++ b/_shows/17_18/rising_tides.md
@@ -7,6 +7,7 @@ period: Spring
 venue: New Theatre
 date_start: 2018-06-02
 date_end: 2018-06-03
+student_written: true 
 
 cast:
 - role: Ryan

--- a/_shows/17_18/strangers_mindreader.md
+++ b/_shows/17_18/strangers_mindreader.md
@@ -7,6 +7,7 @@ period: Spring
 venue: New Theatre Studio A
 date_start: 2018-06-16
 company: Strickland Productions
+student_written: true 
 
 crew_incomplete: false
 

--- a/_shows/17_18/timon_titus.md
+++ b/_shows/17_18/timon_titus.md
@@ -2,6 +2,7 @@
 title: Timon/Titus by William Shakespeare
 playwright: Collectif OS'O
 translator: Ben Standish
+student_written: true 
 period: Autumn
 season: In House
 season_sort: 130

--- a/_shows/18_19/animali_violenti.md
+++ b/_shows/18_19/animali_violenti.md
@@ -8,6 +8,7 @@ season_sort: 530
 date_start: 2019-06-18
 date_end: 2019-06-18
 venue: New Theatre Studio A
+student_written: true 
 
 cast:
 - name: Jonathan Taylor Davies

--- a/_shows/18_19/apollo_take_111.md
+++ b/_shows/18_19/apollo_take_111.md
@@ -8,6 +8,7 @@ period: Spring
 venue: New Theatre 
 date_start: 2019-06-18
 date_end: 2019-06-18
+student_written: true 
 
 cast: 
 - role: Stuart James / Vladimir

--- a/_shows/18_19/decline_rise.md
+++ b/_shows/18_19/decline_rise.md
@@ -7,6 +7,7 @@ period: Spring
 venue: New Theatre Studio A  
 date_start: 2019-06-18
 date_end: 2019-06-18
+student_written: true 
 
 cast: 
 - role: Time

--- a/_shows/18_19/doctor_faustus.md
+++ b/_shows/18_19/doctor_faustus.md
@@ -1,8 +1,4 @@
 ---
-# Check out the Show Docs for more information 
-# -- https://history.newtheatre.org.uk/docs/show/
-# Remove or comment any lines that are not being used 
-
 title: Doctor Faustus
 playwright: Christopher Marlowe
 adaptor: Daniel McVey
@@ -12,6 +8,7 @@ season_sort: 130
 date_start: 2018-11-28
 date_end: 2018-12-01
 venue: New Theatre
+student_written: true 
 
 trivia:
   - quote: I got grief every day for how little of that sodding jigsaw I finished over the course of the show, despite a) not being able to see what it was supposed to be and b) the fact that when completed it would have been bigger than the table I had to work with.

--- a/_shows/18_19/hard_truths.md
+++ b/_shows/18_19/hard_truths.md
@@ -7,6 +7,7 @@ season_sort: 190
 date_start: 2019-01-26
 date_end: 2019-01-31
 venue: New Theatre
+improvised: true
 
 cast:
 - name: Joe Strickland

--- a/_shows/18_19/hard_truths_stuff.md
+++ b/_shows/18_19/hard_truths_stuff.md
@@ -7,6 +7,7 @@ season_sort: 560
 date_start: 2019-06-18
 date_end: 2019-06-18
 venue: New Theatre
+improvised: true
 
 cast:
 - name: Joe Strickland

--- a/_shows/18_19/ophelia.md
+++ b/_shows/18_19/ophelia.md
@@ -7,6 +7,7 @@ venue: New Theatre Studio A
 date_start: 2019-06-18
 date_end: 2019-06-18
 playwright: Emma White
+student_written: true 
   
 cast: 
 - role: Ophelia

--- a/_shows/18_19/polly.md
+++ b/_shows/18_19/polly.md
@@ -8,6 +8,7 @@ season_sort: 580
 date_start: 2019-06-18
 date_end: 2019-06-18
 venue: New Theatre 
+student_written: true
 
 cast:
 - role: Polly / Themselves 

--- a/_shows/18_19/the_importance_of_being_earnest.md
+++ b/_shows/18_19/the_importance_of_being_earnest.md
@@ -9,6 +9,7 @@ season_sort: 30
 date_start: 2018-09-27
 venue: New Theatre
 company: 72 in 72
+student_written: true 
 
 prod_shots: 6cndW2
 

--- a/_shows/18_19/through_no_fault_of_our_own.md
+++ b/_shows/18_19/through_no_fault_of_our_own.md
@@ -6,6 +6,7 @@ season_sort: 450
 date_start: 2019-06-17
 date_end: 2019-06-17
 venue: New Theatre Studio A
+improvised: true
 
 trivia:
   - quote: "Ian and I agreed to do this show on 2 and a half hour's notice, with me not having improvised since 2016."

--- a/_shows/19_20/afterlife_an_improvised_spectre-cle.md
+++ b/_shows/19_20/afterlife_an_improvised_spectre-cle.md
@@ -7,6 +7,7 @@ season_sort: 210
 date_start: 2020-02-04
 date_end: 2020-02-07
 venue: New Theatre
+improvised: true
 
 cast:
 - name: Alex Levy

--- a/_shows/19_20/edward_the_second.md
+++ b/_shows/19_20/edward_the_second.md
@@ -9,6 +9,7 @@ season_sort: 100
 date_start: 2019-12-10
 date_end: 2019-12-13
 venue: New Theatre
+student_written: true 
 
 cast:
 - role: Edward II

--- a/_shows/19_20/higher.md
+++ b/_shows/19_20/higher.md
@@ -8,6 +8,7 @@ season_sort: 55
 date_start: 2019-11-17
 date_end: 2019-11-18
 venue: New Theatre Studio A
+student_written: true 
 
 cast:
 - role: A

--- a/_shows/19_20/kiss_my_neck_not_my_lips.md
+++ b/_shows/19_20/kiss_my_neck_not_my_lips.md
@@ -7,6 +7,7 @@ season_sort: 280
 date_start: 2020-03-16
 date_end: 2020-03-16
 venue: New Theatre Studio A
+student_written: true 
 
 cast:
 - role: Hen

--- a/_shows/19_20/midsummer.md
+++ b/_shows/19_20/midsummer.md
@@ -8,6 +8,7 @@ season_sort: 60
 date_start: 2019-11-20
 date_end: 2019-11-23
 venue: New Theatre
+student_written: true 
 
 # trivia: 
 

--- a/_shows/19_20/pilgrimage.md
+++ b/_shows/19_20/pilgrimage.md
@@ -7,6 +7,7 @@ season_sort: 260
 date_start: 2020-03-09
 date_end: 2020-03-10
 venue: New Theatre Studio A
+student_written: true 
 
 cast:
 - role: Max

--- a/_shows/19_20/to_become_a_king.md
+++ b/_shows/19_20/to_become_a_king.md
@@ -7,6 +7,7 @@ season_sort: 70
 date_start: 2019-11-24
 date_end: 2019-11-25
 venue: New Theatre Studio A
+student_written: true 
 
 cast:
 - role: Prince / Newscaster 3


### PR DESCRIPTION
- Add devised to the list by-line
- Implement support for improvised shows, adding this to the show page and show lists.
- Add improvised and student_written to various shows where missing.

Closes #434, #870