### PR TITLE
Fail the build on invalid front matter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ color_nnt_orange: "#FFC425"
 # Build settings
 markdown: kramdown
 permalink: pretty
+strict_front_matter: true # Fail on invalid YAML
 
 plugins:
 - jekyll-sitemap


### PR DESCRIPTION
Plot twist! This has existed since [2017](https://github.com/jekyll/jekyll/pull/5832), so we should be able to use it now.

Have made it fail locally, so let's hope everything works with Jekyll 3.7.2.

Closes #987