### PR TITLE
Delete chloe_schlitter.md

### DIFF
--- a/_people/chloe_schlitter.md
+++ b/_people/chloe_schlitter.md
@@ -1,6 +1,0 @@
----
-title: Chloe Schlitter
-headshot: kMxScQr
-gender: female
-submitted: false
----


### PR DESCRIPTION
Headshot and surname removed at individual's request.

Followup of fc6e6aa24966388eb2153347df7d1d51b9127203, this PR removes the person file leftover.