### PR TITLE
Improve copy of forms

### DIFF
--- a/_coffee/app/collect.coffee
+++ b/_coffee/app/collect.coffee
@@ -121,7 +121,7 @@ published: true
         career_choices_formatted += $(this).attr('name') + ", "
         career_choices_yaml += "  - " + $(this).attr('name') + "\n"
 
-    message = """# 'Submit an almni bio' form submission
+    message = """# 'Submit an alumni bio' form submission
 
 Field | Data
 ----- | ----

--- a/_content/collect/person/index.html
+++ b/_content/collect/person/index.html
@@ -147,7 +147,7 @@ President - 2001-2002"></textarea>
 
     <div class="collect-row">
       <div class="collect-message">
-        <p>Almost done, please check the following page for next steps.</p>
+        <p>That's it! Pressing submit will send all the details off to the editorial team.</p>
       </div>
       <div class="collect-controls">
         <button class="collect-submit" type="submit">Submit</button>

--- a/_content/collect/person/thanks.html
+++ b/_content/collect/person/thanks.html
@@ -18,7 +18,7 @@ permalink: /collect/person/thanks/
     <h2>Thanks!</h2>
 
     <p>Our editors have been informed of your submission and will add it to the site in the near future. If additional details are needed from you we may contact you via your alumni membership contact details (if you are registered).</p>
-    <p>We cannot contact you directly if you are not registered with the Alumni Network. Please email <a href="history@newtheatre.org.uk">history@newtheatre.org.uk</a> if you are looking for a response.</p>
+    <p>We cannot contact you directly if you are not registered with the Alumni Network. Please email <a href="mailto:history@newtheatre.org.uk">history@newtheatre.org.uk</a> if you are looking for a response.</p>
 
     <div class="collect-next-steps">
       <div class="step">

--- a/_content/collect/person/thanks.html
+++ b/_content/collect/person/thanks.html
@@ -17,7 +17,8 @@ permalink: /collect/person/thanks/
 
     <h2>Thanks!</h2>
 
-    <p>Our editors have been informed of your submission and will add it to the site in the near future. If additional details are needed from you we may contact you via your alumni membership contact details.</p>
+    <p>Our editors have been informed of your submission and will add it to the site in the near future. If additional details are needed from you we may contact you via your alumni membership contact details (if you are registered).</p>
+    <p>We cannot contact you directly if you are not registered with the Alumni Network. Please email <a href="history@newtheatre.org.uk">history@newtheatre.org.uk</a> if you are looking for a response.</p>
 
     <div class="collect-next-steps">
       <div class="step">

--- a/_content/collect/show/index.html
+++ b/_content/collect/show/index.html
@@ -120,7 +120,7 @@ Set Designer - Chelsea Jayne Wright"></textarea>
 
     <div class="collect-row">
       <div class="collect-message">
-        <p>Almost done, please check the following page for next steps.</p>
+        <p>That's it! Pressing submit will send all the details off to the editorial team.</p>
       </div>
       <div class="collect-controls">
         <button class="collect-submit" type="submit">Submit</button>

--- a/_content/collect/show/thanks.html
+++ b/_content/collect/show/thanks.html
@@ -18,7 +18,7 @@ permalink: /collect/show/thanks/
     <h2>Thanks!</h2>
 
     <p>Our editors have been informed of your report and will add it to the site in the near future. If additional details are needed from you we may contact you via your alumni membership contact details.</p>
-    <p>We cannot contact you directly if you are not registered with the Alumni Network. Please email <a href="history@newtheatre.org.uk">history@newtheatre.org.uk</a> if you are looking for a response.</p>
+    <p>We cannot contact you directly if you are not registered with the Alumni Network. Please email <a href="mailto:history@newtheatre.org.uk">history@newtheatre.org.uk</a> if you are looking for a response.</p>
 
     <div class="collect-next-steps">
       <div class="step">

--- a/_content/collect/show/thanks.html
+++ b/_content/collect/show/thanks.html
@@ -18,6 +18,7 @@ permalink: /collect/show/thanks/
     <h2>Thanks!</h2>
 
     <p>Our editors have been informed of your report and will add it to the site in the near future. If additional details are needed from you we may contact you via your alumni membership contact details.</p>
+    <p>We cannot contact you directly if you are not registered with the Alumni Network. Please email <a href="history@newtheatre.org.uk">history@newtheatre.org.uk</a> if you are looking for a response.</p>
 
     <div class="collect-next-steps">
       <div class="step">

--- a/_includes/report.html
+++ b/_includes/report.html
@@ -34,6 +34,7 @@
       <p>You can use the form below to post to our public <a href="https://github.com/newtheatre/history-project/issues">
         issue tracker</a> about the page you're currently on &ndash; <strong>{{ page.title | escape_once }}</strong>. Let us know about
         missing or incorrect details, typos or any other way this page could be improved.</p>
+        <p>We cannot respond directly to any submissions from this form. Please email <a href="mailto:history@newtheatre.org.uk">history@newtheatre.org.uk</a> if you are looking for a response.</p>
       <div class="report-form">
         <form id="report-issue-form" action="{{ site.ntbot_endpoint }}" method="POST">
           <input class="report-text" type="text" id="report-title" required placeholder="Subject" />


### PR DESCRIPTION
People often contact us and leave no way of contacting them. Rather than advising them to make their email addresses public, I've added some copy to encourage them to email in.