### PR TITLE
Provide playwrights with a credit

### DIFF
--- a/_data/defs/show.yaml
+++ b/_data/defs/show.yaml
@@ -10,6 +10,16 @@
   short: Full name of the playwright
   description: "Omit if using devised, set to `various` if compilation."
 
+- attr: playwright_false 
+  type: boolean 
+  short: Exclude student playwright from crew list 
+  description: "Only used when `student_written: true`. Excludes the student adaptor, translator, or playwright from the crew list."
+
+- attr: playwright_alias 
+  type: string 
+  short: Student name of the playwright 
+  description: "Student playwrights occasionally use aliases to write under. Use their student name here to ensure attribution is given in the crew list."
+
 - attr: devised
   short: Used if play was devised
   description: "Either `true` for generic output or a descriptor. Example descriptor: `Cast and Crew` will output “Devised by Cast and Crew”. Omit if using playwright."
@@ -54,7 +64,7 @@
 - attr: student_written
   type: boolean
   short: Show written by a NNT member
-  description: "Set to `true`; `false` or line missing are equivalent."
+  description: "Set to `true`; `false` or line missing are equivalent. In order of precedence, the adaptor, translator, or playwright are then given a role in the crew list. Suppress this behaviour with `playwright_false`"
 
 - attr: company
   type: string

--- a/_data/roles.yaml
+++ b/_data/roles.yaml
@@ -4,6 +4,14 @@
 
 # - role: Acting
 
+- role: Playwright 
+  icon: fa fa-pencil 
+  aliases: 
+    - Author 
+    - Writer 
+    - Adaptor
+    - Translator 
+
 - role: Director
   icon: ion-film-marker
   aliases:

--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -244,7 +244,7 @@ module Jekyll
         if not student_playwright.include?(" and ") and not student_playwright.include?(", ") and not student_playwright.include?(" & ")
           # Exclude multiple playwrights 
           if show.data.key?("playwright_alias")
-            # Students often write under different names. Offer the ability to account for that and still attribute appropriately.
+            # Students often write under different names. Offer the ability to account for that and still attribute appropriately. Related to #965.
             student_playwright = {"role"=>playwright_role, "name"=>show.data["playwright_alias"]}
           else
             student_playwright = {"role"=>playwright_role, "name"=>student_playwright}

--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -228,6 +228,39 @@ module Jekyll
 
       # Add extra data to cast / crew lists
       show.data["cast"] = generate_show_pls(show, "cast")
+
+      if show.data.key?("student_written") and show.data["student_written"] and show.data.key?("playwright") and not show.data["playwright"].nil? and not show.data["playwright_false"]
+        if show.data.key?("adaptor") and not show.data["adaptor"].nil?
+          student_playwright = show.data["adaptor"]
+          playwright_role = "Adaptor"
+        elsif show.data.key?("translator") and not show.data["translator"].nil?
+          student_playwright = show.data["translator"]
+          playwright_role = "Translator"
+        else 
+          student_playwright = show.data["playwright"]
+          playwright_role = "Playwright"
+        end 
+
+        if not student_playwright.include?(" and ") and not student_playwright.include?(", ") and not student_playwright.include?(" & ")
+          # Exclude multiple playwrights 
+          if show.data.key?("playwright_alias")
+            # Students often write under different names. Offer the ability to account for that and still attribute appropriately.
+            student_playwright = {"role"=>playwright_role, "name"=>show.data["playwright_alias"]}
+          else
+            student_playwright = {"role"=>playwright_role, "name"=>student_playwright}
+          end 
+          if show.data.key?("crew")
+            if not show.data["crew"].include?(playwright_role)
+              show.data["crew"].unshift(student_playwright)
+            else
+              Jekyll.logger.warn show.data["title"] + " has student playwright set manually"
+            end
+          else 
+            show.data["crew"] = [student_playwright]
+          end 
+        end
+      end 
+
       show.data["crew"] = generate_show_pls(show, "crew")
 
       # Process trivia

--- a/_plugins/show.rb
+++ b/_plugins/show.rb
@@ -251,11 +251,13 @@ module Jekyll
           end 
           if show.data.key?("crew")
             if not show.data["crew"].include?(playwright_role)
+              # Add the playwright to the top of the crew list 
               show.data["crew"].unshift(student_playwright)
             else
               Jekyll.logger.warn show.data["title"] + " has student playwright set manually"
             end
           else 
+            # No existing crew list? No problem.
             show.data["crew"] = [student_playwright]
           end 
         end

--- a/_shows/07_08/good_morning_and_goodbye.md
+++ b/_shows/07_08/good_morning_and_goodbye.md
@@ -14,6 +14,16 @@ crew:
       name: Nick Moran
 
 prod_shots: CMNPKh
+
+links:
+  - type: Review
+    href: http://www.su-web2.nottingham.ac.uk/~impact/?p=939
+    snapshot: tTeQl
+    publisher: Impact Nottingham
+    author: James Daunt
+    title: "The Box & Good Morning and Goodbye @ The New Theatre"
+    date: 2008-05-08
+    quote: "The quintessential smarmy hosts are played with verve, and the play revolves around a most abnormal day unfolding on the set of Good Morning & Goodbye."
 ---
 
 Breakfast television talk shows are dull, lifeless and insipid, that is one thing that is beyond certain. And even the long suffering cast of 'Good morning and Goodbye' - Britain's 'most cheery way to start the day' - forced to live in a never-ending Prozac-laced world of pseudo-happiness, would not disagree with any accusation of blandness. However, today is a day unlike any other. A tremendous romp featuring religious cultists, celebrity chefs finally getting their due, and the truth about cold freezing, 'Good Morning and Goodbye' promises to deliver a slew of laughs and maybe even more...

--- a/_shows/07_08/the_box.md
+++ b/_shows/07_08/the_box.md
@@ -25,7 +25,7 @@ links:
     author: James Daunt
     title: "The Box & Good Morning and Goodbye @ The New Theatre"
     date: 2008-05-08
-    quote: "The quintessential smarmy hosts are played with verve, and the play revolves around a most abnormal day unfolding on the set of Good Morning & Goodbye."
+    quote: "Not without lewd references and considerable profanity from James, the couple illustrate their sense of dejection from past events and desperation about the future with forceful conviction."
 ---
 
 The story of a young teenage couple who deliberately encase themselves in a giant concrete box. As people on the outside try to force their way in, Jess and James make the walls thicker, and the two explore their own stories, their thoughts and feelings about love, and the terrifying and traumatic events that lead them to build 'the box'. A dark, macabre and often grotesque story about how sometimes love will always prevail, even if it means isolation, and possible death.

--- a/_shows/11_12/innocent_infidelity.md
+++ b/_shows/11_12/innocent_infidelity.md
@@ -1,6 +1,8 @@
 ---
 title: Innocent Infidelity
 playwright: C. J. Willman
+playwright_alias: Craig Willman 
+student_written: true 
 season: In House
 season_sort: 240
 period: Spring

--- a/_shows/11_12/porphyria.md
+++ b/_shows/11_12/porphyria.md
@@ -1,6 +1,7 @@
 ---
 title: "Porphyria"
 playwright: "C. J. Willman"
+playwright_alias: Craig Willman
 student_written: true
 period: Edinburgh
 season: Edinburgh

--- a/_shows/14_15/reservoir_dogs.md
+++ b/_shows/14_15/reservoir_dogs.md
@@ -1,6 +1,6 @@
 ---
 title: "Reservoir Dogs"
-playwright: "Quenton Tarantino"
+playwright: "Quentin Tarantino"
 student_written: true
 adaptor: Carn Truscott
 period: Spring

--- a/_shows/15_16/the_great_gatsby.md
+++ b/_shows/15_16/the_great_gatsby.md
@@ -2,6 +2,7 @@
 title: The Great Gatsby
 playwright: F. Scott Fitzgerald
 adaptor: "L. J. Bateman"
+playwright_alias: Laura Jayne Bateman
 student_written: true
 season: Fringe
 season_sort: 110

--- a/_shows/15_16/the_great_gatsby_edin.md
+++ b/_shows/15_16/the_great_gatsby_edin.md
@@ -2,6 +2,7 @@
 title: The Great Gatsby
 playwright: F. Scott Fitzgerald
 adaptor: "L. J. Bateman"
+playwright_alias: Laura Jayne Bateman
 student_written: true
 period: Edinburgh
 season: Edinburgh

--- a/_shows/15_16/the_great_gatsby_stuff.md
+++ b/_shows/15_16/the_great_gatsby_stuff.md
@@ -2,6 +2,7 @@
 title: The Great Gatsby
 playwright: F. Scott Fitzgerald
 adaptor: "L. J. Bateman"
+playwright_alias: Laura Jayne Bateman
 student_written: true
 period: Spring
 season: StuFF

--- a/_shows/16_17/the_great_gatsby.md
+++ b/_shows/16_17/the_great_gatsby.md
@@ -2,6 +2,7 @@
 title: The Great Gatsby
 playwright: F. Scott Fitzgerald
 adaptor: "L. J. Bateman"
+playwright_alias: Laura Jayne Bateman
 student_written: true
 season: Lakeside
 season_sort: 20

--- a/_shows/19_20/72_alice_in_wonderland.md
+++ b/_shows/19_20/72_alice_in_wonderland.md
@@ -75,7 +75,7 @@ crew:
 - role: Poster Designer
   name: Caitie Pardoe
 - role: Technical Operator 
-  name: Tara Prasad
+  name: Tara Anegada
 - role: Technical Operator
   name: James Barlow
 

--- a/_shows/20_21/familiar_strangers.md
+++ b/_shows/20_21/familiar_strangers.md
@@ -2,6 +2,7 @@
 
 title: Familiar Strangers
 playwright: M Craig
+playwright_alias: Madeleine Craig
 student_written: true
 period: Autumn
 season: Online

--- a/_shows/20_21/madhouse_ed.md
+++ b/_shows/20_21/madhouse_ed.md
@@ -2,6 +2,7 @@
 
 title: Madhouse
 playwright: M Craig
+playwright_alias: Madeleine Craig
 student_written: true
 period: Edinburgh
 season: Edinburgh


### PR DESCRIPTION
For student written shows with one listed playwright, list them in the crew list and provide them with a credit on the person page. 

Additionally add `playwright_false` as an override to suppress this, alongside `playwright_alias` for students who write under a different name (eg M Craig).

<img width="639" alt="Screenshot 2021-12-21 at 10 57 41 AM" src="https://user-images.githubusercontent.com/15388319/146919039-88af5eed-0de5-4817-a6ba-6f2b1ecaf7be.png">
<img width="211" alt="Screenshot 2021-12-21 at 10 57 53 AM" src="https://user-images.githubusercontent.com/15388319/146919047-7e57f81c-7d02-48c9-be0f-6c3cbfbedd2b.png">
<img width="628" alt="Screenshot 2021-12-21 at 10 57 59 AM" src="https://user-images.githubusercontent.com/15388319/146919051-9b79e036-e208-4027-b21f-2db4fbb086b5.png">
