### PR TITLE
Add interview with Joanne on Impact

### DIFF
--- a/_people/joanne_blunt.md
+++ b/_people/joanne_blunt.md
@@ -7,4 +7,13 @@ award: Fellowship
 submitted: false
 course:
  - Physics with German
+
+links:
+  - type: Article
+    href: https://impactnottingham.com/2016/04/spotlight-on-technical-directing/
+    snapshot: snQQX
+    publisher: Impact Magazine
+    title: SPOTLIGHT ON… TECHNICAL DIRECTING
+    date: 2016-04-16
+    quote: "The greatest part of TDing is of course opening night, when you’ve made some inevitable mistakes but fixed them with quick thinking so nobody noticed, had a hug from the director and producer and you head off home ready to do it all again the following evening."
 ---

--- a/_people/joanne_blunt.md
+++ b/_people/joanne_blunt.md
@@ -8,7 +8,7 @@ submitted: false
 course:
  - Physics with German
 
-links:
+news:
   - type: Article
     href: https://impactnottingham.com/2016/04/spotlight-on-technical-directing/
     snapshot: snQQX


### PR DESCRIPTION
Joanne did an interview with Impact that feels very relevant to archive.

I figured her person page was the best place to put it, **but** links on person pages always go in the 'Now' section. Is this ok? 