### PR TITLE
Merge 'Then & Now' columns into 'Now' column for students

### DIFF
--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -81,7 +81,7 @@ body_class: layout-person header-nobr content-nobr
       <div class="box-warning">
         <i class="fa fa-question"></i>
         <h3>Missing Biography</h3>
-        <p>We are collecting biographies on New Theatre alumni, if this is you please <a href="{{ submit_link }}">submit one here</a>.</p>
+        <p>We are collecting biographies on New Theatre {% if person.student %}members{% else %}alumni{% endif %}, if this is you please <a href="{{ submit_link }}">submit one here</a>.</p>
       </div>
     </div>
     {% endif %}

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -86,8 +86,8 @@ body_class: layout-person header-nobr content-nobr
     </div>
     {% endif %}
 
-    <section class="person-past">
-      <h2>Then</h2>
+    <section class="person-{% if person.student %}current{% else %}past{% endif %}">
+      <h2>{% if person.student %}Now{% else %}Then{% endif %}</h2>
       <dl class="person-meta-list">
         {% for course in person.course %}
           <dt><i class="fa fa-fw fa-book"></i>Course</dt>
@@ -120,10 +120,15 @@ body_class: layout-person header-nobr content-nobr
         </dd>
         {% endif %}
       </dl>
+      {% if person.student %}
+        {% include link-list.html links=person.links %}
+
+        {% include link-list.html links=person.news %}
+      {% endif %}
     </section>
 
-    {% if person.placeholder == false %}
-    <!-- Person has a file -->
+    {% if person.placeholder == false and person.student == false %}
+    <!-- Person has a file and is not a student -->
 
     <section class="person-current">
       <h2>Now</h2>

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -145,6 +145,12 @@ body_class: layout-person header-nobr content-nobr
 
       {% include link-list.html links=person.news %}
 
+      {% if person.careers.size == 0 and person.links.size == 0 and person.news.size == 0 %}
+        <p class="micro">
+          <a href="https://github.com/newtheatre/history-project/issues/new?body={{page.url}}" class="subtle" data-proofer-ignore data-report-this-page>We don't know what {{ person.title | escape_once }} is up to now. Can you help? Message the editors.&hellip;</a>
+        </p>
+      {% endif %}
+
     </section>
 
     {% endif %}


### PR DESCRIPTION
And improve the CTAs for people while we're here.

Would appreciate feedback on the CTA for submitting 'Now' information. It feels a little forced / invasive perhaps? I dislike the empty column though.

**Single-column student view**
<img width="1085" alt="Screenshot 2021-12-23 at 8 56 35 PM" src="https://user-images.githubusercontent.com/15388319/147291687-61bda8d4-16ae-4522-894b-5bca2eb03fd6.png">

**'Now' column CTA**
<img width="559" alt="Screenshot 2021-12-23 at 9 10 00 PM" src="https://user-images.githubusercontent.com/15388319/147291707-ef5006bf-8d51-453f-afad-242f290a5437.png">
