### PR TITLE
Sweep through open report tool issues and add what we can

### DIFF
--- a/_people/ellie_colyer.md
+++ b/_people/ellie_colyer.md
@@ -1,6 +1,7 @@
 ---
 title: Ellie Colyer 
 alias: Ellie Fox
+headshot: dXtRmWf
 course:
   - BA Hons (2:1) Hispanic & Latin American Studies
 graduated: 2000

--- a/_people/jaime_wynne.md
+++ b/_people/jaime_wynne.md
@@ -1,0 +1,12 @@
+---
+title: Jaime Wynne
+submitted: 2024-08-05
+course:
+  - Psychology & Philosophy BSc
+graduated: 2020
+contact_allowed: true
+---
+
+Flinging a copy of the script on stage during 72 in 72 to the white rabbit. He completely missed it and it just lay on the floor and I had to crawl out of the wings to retrieve it (I hadn't yet been introduced to the audience.)
+
+Still love theatre! Worked as a PA for an agent for a bit of time before deciding to get my PGCE.

--- a/_people/terrence_payne.md
+++ b/_people/terrence_payne.md
@@ -1,5 +1,6 @@
 ---
 title: Terrence Payne
+alias: Terry Payne
 gender: male
 graduated: 1999
 course:

--- a/_shows/00_01/breakfast_not_included.md
+++ b/_shows/00_01/breakfast_not_included.md
@@ -4,7 +4,7 @@ playwright: Alison Carr
 student_written: true
 season: Edinburgh
 period: Edinburgh
-season_sort: 40
+season_sort: 400
 
 cast:
  - name: Jamie Griffiths

--- a/_shows/00_01/lucid_dreaming.md
+++ b/_shows/00_01/lucid_dreaming.md
@@ -1,0 +1,12 @@
+---
+title: Lucid Dreaming
+playwright: Josh Dean
+student_written: true
+season: Edinburgh
+period: Edinburgh
+season_sort: 420
+comment: "Recorded from #340, one of the three Edinburgh shows that year. No cast or crew known."
+
+cast_incomplete: true
+crew_incomplete: true
+---

--- a/_shows/19_20/72_alice_in_wonderland.md
+++ b/_shows/19_20/72_alice_in_wonderland.md
@@ -9,6 +9,11 @@ date_start: 2019-09-27
 date_end: 2019-09-27
 venue: New Theatre
 
+trivia:
+  - quote: Flinging a copy of the script on stage during 72 in 72 to the white rabbit. He completely missed it and it just lay on the floor and I had to crawl out of the wings to retrieve it (I hadn't yet been introduced to the audience.)
+    name: Jaime Wynne
+    submitted: 2024-08-05
+
 cast:
 - role: Alice
   name: Emi Thackray

--- a/_shows/21_22/the_lacehouse.md
+++ b/_shows/21_22/the_lacehouse.md
@@ -11,7 +11,7 @@ venue: New Theatre Studio A
 
 cast:
 - role: Eldest
-  name: Kathyrn Parry
+  name: Kathryn Parry
 - role: Middle
   name: Marianna Whistlecroft
 - role: Youngest

--- a/_shows/74_75/krapps_last_tape.md
+++ b/_shows/74_75/krapps_last_tape.md
@@ -1,0 +1,32 @@
+---
+title: "Krapp's Last Tape"
+playwright: Samuel Beckett
+season: In House
+season_sort: 140
+
+cast_incomplete: true
+crew_incomplete: true
+
+tour:
+  - venue: Northampton
+    notes: Toured with The Dumb Waiter
+
+cast:
+  - role: Krapp
+    name: Hugh Simon
+
+crew:
+  - role: Director
+    name: Mark Everett
+    note: unconfirmed
+  - role: Stage Manager
+    name: John Schwiller
+  - role: Set Designer
+    name: John Schwiller
+  - role: Sound
+    name: Chris Toms
+
+comment: "The year is inferred rather than recorded. Mark Everett's other credits run 71_72 to 74_75 and stop there, and Phil Barnes, who appears in the companion piece, likewise has no credit after 74_75. Against that, Chris Toms's other credits all fall in 75_76 or later, so this would be his earliest known involvement. Submitted by John Schwiller."
+---
+
+Staged as a double bill with The Dumb Waiter: the two shared a stage manager and set designer in John Schwiller, and toured together to Northampton.

--- a/_shows/74_75/the_dumb_waiter.md
+++ b/_shows/74_75/the_dumb_waiter.md
@@ -1,0 +1,33 @@
+---
+title: The Dumb Waiter
+playwright: Harold Pinter
+season: In House
+season_sort: 140
+
+crew_incomplete: true
+
+tour:
+  - venue: Northampton
+    notes: Toured with Krapp's Last Tape
+
+cast:
+  - role: unknown
+    name: Nick Frost
+  - role: unknown
+    name: Phil Barnes
+
+crew:
+  - role: Director
+    name: Mark Everett
+    note: unconfirmed
+  - role: Stage Manager
+    name: John Schwiller
+  - role: Set Designer
+    name: John Schwiller
+
+comment: "The year is inferred rather than recorded. Mark Everett's other credits run 71_72 to 74_75 and stop there, and Phil Barnes likewise has no credit after 74_75; the three of them overlap only in 74_75. Submitted by John Schwiller."
+---
+
+Staged as a double bill with Krapp's Last Tape: the two shared a stage manager and set designer in John Schwiller, and toured together to Northampton.
+
+Nick Frost, who later took the name Nicholas Farrell, and Phil Barnes played Ben and Gus, though which took which role is not recorded.

--- a/_shows/75_76/journeys_end.md
+++ b/_shows/75_76/journeys_end.md
@@ -25,6 +25,12 @@ trivia:
       I remember this show so well. I designed the set to break through the fourth wall and we constructed timber beams in front of the proscenium. Mike Wolfe lit the show with Patt 23s in the beams. The only thing I wasn’t happy with was the hurried painted sandbags at the top of the steps. Also that the wonderful John Turner (Benfield) couldn’t make the shoot of all the cast and crew. At the end of the show the dugout had to collapse and we used a hinged ceiling with fullers earth. We could only afford a maroon or two for each night so for rehearsals I shouted “maroon”. This became a running gag, for example when I ran into Nick Farrell on Shaftesbury Avenue.
     name: John Schwiller
     submitted: 2025-08-01
+  - quote: "The boys in Journey's End all went together to the barbers and had their long hair chopped off so they looked like authentic WW1 soldiers."
+    name: Terri Norris
+    submitted: 2019-03-28
+  - quote: "As Private Evans, I served a meal, which was actually consumed, but to judge from their expressions were rather disgusting!"
+    name: Stephen Hopker
+    submitted: 2020-03-25
 
 
 cast:
@@ -56,20 +62,16 @@ crew:
     name: John Thewlis
   - role: Stage Manager and Pyrotechnician
     name: John Schwiller
+  - role: Set Designer
+    name: John Schwiller
+  - role: Construction
+    name: John Schwiller
 
 assets:
   - type: poster
     image: v484CKN
 
 prod_shots: 5KMVL7
-
-trivia:
-  - quote: "The boys in Journey's End all went together to the barbers and had their long hair chopped off so they looked like authentic WW1 soldiers."
-    name: Terri Norris
-    submitted: 2019-03-28
-  - quote: "As Private Evans, I served a meal, which was actually consumed, but to judge from their expressions were rather disgusting!"
-    name: Stephen Hopker
-    submitted: 2020-03-25
 ---
 
 Journey's End is a 1928 drama, the seventh of English playwright R. C. Sherriff.

--- a/_shows/78_79/the_threepenny_opera.md
+++ b/_shows/78_79/the_threepenny_opera.md
@@ -1,7 +1,7 @@
 ---
 title: The Threepenny Opera
 season: In House
-playwright: John Gay
+playwright: Bertolt Brecht
 translator: Elisabeth Hauptmann
 season_sort: 310
 comment: "Could be 77-78, or 78-79, see #239"

--- a/_shows/94_95/west_side_story.md
+++ b/_shows/94_95/west_side_story.md
@@ -128,7 +128,7 @@ prod_shots: bC8xDt
 
 trivia:
   - quote: At that time the stage  was very high from the ground and not flat as it is now, and I remember coming off full of myself as you are when you have just been on stage, and stepping down in to nothing and making a nasty graze on my shin bone.
-    name: Terry Payne
+    name: Terrence Payne
     submitted: 2018-07-02
 
 ---


### PR DESCRIPTION
## New records
- **"Krapp's Last Tape" / "The Dumb Waiter" (74-75)** — Beckett/Pinter double bill that toured to Northampton, from John Schwiller's submissions. Year inferred from cast overlap; reasoning and the counter-argument noted in the record bodies. Refs #1840, #1841
- **"Lucid Dreaming" (00-01)** — third Edinburgh show that year, no cast/crew known. Also fixes `season_sort` on "Breakfast Not Included" (40 → 400), which was sorting among Autumn in-house shows. Closes #340
- **Jaime Wynne** — bio from 2024 submission; no careers given so field omitted. Closes #1816

## Corrections
- **"The Threepenny Opera" (78-79)** — playwright John Gay → Bertolt Brecht. Hauptmann's translator credit retained (her German translation of Gay is Brecht's source). Re #1640
- **"Journey's End" (75-76)** — John Schwiller credited with set design. Also merges two duplicate `trivia` keys in the file; the first block's five entries were being dropped at parse time. Closes #1635
- **"The Lacehouse" (21-22)** — Kathyrn Parry typo split from the Kathryn Parry credit in the 22-23 remount. Re #1791
- **Terry Payne → Terrence Payne** in "West Side Story" (94-95), plus `alias: Terry Payne` on his person record, so the trivia attribution lands on his page. Re #1098

## Additions to existing records
- Jaime Wynne's 72 in 72 anecdote added as trivia on "72 in 72: Alice in Wonderland" (19-20). Re #1816
- Headshot for Ellie Colyer